### PR TITLE
Compress draco 2

### DIFF
--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -37,6 +37,7 @@ QT += qml 3dcore 3dcore-private 3drender 3dquickextras 3danimation
 include(core.pri)
 include(collections/collections.pri)
 include(gltf2importer/gltf2importer.pri)
+include(gltf2exporter/gltf2exporter.pri)
 include(framegraphes/framegraphes.pri)
 include(fx/fx.pri)
 

--- a/src/core/gltf2exporter/dracocompressor_p.cpp
+++ b/src/core/gltf2exporter/dracocompressor_p.cpp
@@ -1,0 +1,373 @@
+/*
+    dracocompressor_p.cpp
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Juan Jose Casafranca <juan.casafranca@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <draco/mesh/mesh.h>
+#include <draco/attributes/geometry_attribute.h>
+#include <draco/attributes/geometry_indices.h>
+#include <draco/io/mesh_io.h>
+#include "dracocompressor_p.h"
+#include "gltf2exporter_p.h"
+#include <Qt3DRender/QGeometry>
+#include <Qt3DRender/QAttribute>
+#include <Qt3DRender/QBuffer>
+#include <QVector>
+#include <QFile>
+#include <QLoggingCategory>
+#include <QDataStream>
+#include <fstream>
+#include <iterator>
+#include <iostream>
+
+QT_BEGIN_NAMESPACE
+Q_LOGGING_CATEGORY(dracocompressor, "DracoCompressor")
+namespace Kuesa {
+namespace DracoCompression {
+namespace {
+draco::GeometryAttribute::Type attributeTypeFromName(const QString &attributeName)
+{
+    auto type = draco::GeometryAttribute::Type::INVALID;
+
+    if (attributeName == Qt3DRender::QAttribute::defaultPositionAttributeName())
+        type = draco::GeometryAttribute::Type::POSITION;
+    else if (attributeName == Qt3DRender::QAttribute::defaultNormalAttributeName())
+        type = draco::GeometryAttribute::Type::NORMAL;
+    else if (attributeName == Qt3DRender::QAttribute::defaultColorAttributeName())
+        type = draco::GeometryAttribute::Type::COLOR;
+    else if (attributeName == Qt3DRender::QAttribute::defaultTextureCoordinateAttributeName())
+        type = draco::GeometryAttribute::Type::TEX_COORD;
+    else if (attributeName == Qt3DRender::QAttribute::defaultTextureCoordinate1AttributeName())
+        type = draco::GeometryAttribute::Type::TEX_COORD;
+    else if (attributeName == Qt3DRender::QAttribute::defaultTextureCoordinate2AttributeName())
+        type = draco::GeometryAttribute::Type::TEX_COORD;
+    else if (attributeName == Qt3DRender::QAttribute::defaultTangentAttributeName())
+        type = draco::GeometryAttribute::Type::GENERIC;
+    else if (attributeName == Qt3DRender::QAttribute::defaultJointWeightsAttributeName())
+        type = draco::GeometryAttribute::Type::GENERIC;
+    else if (attributeName == Qt3DRender::QAttribute::defaultJointIndicesAttributeName())
+        type = draco::GeometryAttribute::Type::GENERIC;
+
+    return type;
+}
+
+template<typename T>
+struct attribute_type_trait {
+    static constexpr draco::DataType type = draco::DataType::DT_INVALID;
+};
+
+template<>
+struct attribute_type_trait<float> {
+    static constexpr draco::DataType type = draco::DataType::DT_FLOAT32;
+};
+
+template<>
+struct attribute_type_trait<char> {
+    static constexpr draco::DataType type = draco::DataType::DT_INT8;
+};
+
+template<>
+struct attribute_type_trait<unsigned char> {
+    static constexpr draco::DataType type = draco::DataType::DT_UINT8;
+};
+
+template<>
+struct attribute_type_trait<unsigned short> {
+    static constexpr draco::DataType type = draco::DataType::DT_UINT16;
+};
+
+template<>
+struct attribute_type_trait<short> {
+    static constexpr draco::DataType type = draco::DataType::DT_INT16;
+};
+
+template<>
+struct attribute_type_trait<int> {
+    static constexpr draco::DataType type = draco::DataType::DT_INT32;
+};
+
+template<>
+struct attribute_type_trait<unsigned int> {
+    static constexpr draco::DataType type = draco::DataType::DT_UINT32;
+};
+
+template<>
+struct attribute_type_trait<double> {
+    static constexpr draco::DataType type = draco::DataType::DT_FLOAT64;
+};
+
+template<typename T, typename Sz>
+static constexpr Sz actualStride(Sz glStride, Sz vertexSize)
+{
+    return glStride == 0 ? vertexSize * Sz(sizeof(T)) : glStride;
+}
+
+template<typename T>
+QByteArray packedDataInBuffer(const QByteArray &inputBuffer,
+                              std::size_t vertexSize,
+                              std::size_t offset,
+                              std::size_t stride,
+                              std::size_t count)
+{
+    const auto elementSize = vertexSize * sizeof(T);
+
+    Q_ASSERT_X(count < std::numeric_limits<int>::max() / elementSize, "Kuesa::packedDataInBuffer", "Too many elements for a QByteArray");
+
+    QByteArray outputBuffer(int(count * elementSize), Qt::Uninitialized);
+
+    auto byteMarkerPosition = offset;
+    stride = actualStride<T>(stride, vertexSize);
+
+    for (std::size_t i = 0; i < count; ++i) {
+        std::memcpy(&(outputBuffer.data()[i * elementSize]), &(inputBuffer.data()[byteMarkerPosition]), elementSize);
+        byteMarkerPosition += stride;
+    }
+
+    return outputBuffer;
+}
+
+template<typename T>
+std::pair<QString, int> addAttributeToMesh(const Qt3DRender::QAttribute &attribute, draco::Mesh &mesh)
+{
+    const auto dracoAttributeType = attributeTypeFromName(attribute.name());
+    const auto dracoDataType = attribute_type_trait<T>::type;
+
+    if (dracoAttributeType == draco::GeometryAttribute::Type::POSITION)
+        mesh.set_num_points(attribute.count());
+
+    const auto attributeBuffer = attribute.buffer();
+
+    const QByteArray packedData = packedDataInBuffer<T>(attributeBuffer->data(),
+                                                        attribute.vertexSize(),
+                                                        attribute.byteOffset(),
+                                                        attribute.byteStride(),
+                                                        attribute.count());
+
+    draco::PointAttribute meshAttribute;
+    meshAttribute.Init(attributeTypeFromName(attribute.name()),
+                       nullptr,
+                       static_cast<int8_t>(attribute.vertexSize()),
+                       dracoDataType,
+                       false,
+                       actualStride<T>(attribute.byteStride(), attribute.vertexSize()),
+                       0);
+
+    auto attId = mesh.AddAttribute(meshAttribute, true, attribute.count());
+    if (attId == -1)
+        return { {}, -1 };
+
+    mesh.attribute(attId)->buffer()->Write(0, packedData.data(), static_cast<std::size_t>(packedData.size()));
+
+    return { attribute.property("semanticName").toString(), attId };
+}
+
+template<typename T>
+QVector<draco::PointIndex> createIndicesVectorFromAttribute(const Qt3DRender::QAttribute &attribute)
+{
+    const auto byteOffset = attribute.byteOffset();
+    const auto data = attribute.buffer()->data().mid(int(byteOffset));
+    const auto attrCount = attribute.count();
+    const int stride = actualStride<T>(int(attribute.byteStride()), 1);
+
+    Q_ASSERT_X(attrCount < std::numeric_limits<int>::max(), "Kuesa::createIndicesVectorFromAttribute", "Too many elements for a QVector");
+
+    QVector<draco::PointIndex> indicesVector(static_cast<int>(attrCount));
+
+    for (int i = 0, n = int(attrCount); i < n; ++i)
+        indicesVector[i] = *reinterpret_cast<const T *>(data.data() + i * stride);
+
+    return indicesVector;
+}
+
+void addFacesToMesh(const QVector<draco::PointIndex> &indices, draco::Mesh &dracoMesh)
+{
+    for (int i = 0, nbIndices = indices.size() / 3; i < nbIndices; ++i)
+        dracoMesh.AddFace({ indices[3 * i + 0],
+                            indices[3 * i + 1],
+                            indices[3 * i + 2] });
+}
+
+template<typename T>
+bool compressAttribute(
+        const Qt3DRender::QAttribute &attribute,
+        draco::Mesh &dracoMesh,
+        std::vector<std::pair<QString, int>>& attributes)
+{
+    auto compressedAttr = addAttributeToMesh<T>(attribute, dracoMesh);
+    if (compressedAttr.second == -1) {
+        qCWarning(dracocompressor) << "Could not add attribute to mesh: " << attribute.name();
+        return false;
+    }
+    attributes.push_back(compressedAttr);
+    return true;
+}
+
+Q_DECL_RELAXED_CONSTEXPR
+draco::GeometryAttribute::Type dracoAttribute(GLTF2ExportConfiguration::MeshAttribute m)
+{
+    switch (m) {
+    case GLTF2ExportConfiguration::Position:
+        return draco::GeometryAttribute::POSITION;
+    case GLTF2ExportConfiguration::Normal:
+        return draco::GeometryAttribute::NORMAL;
+    case GLTF2ExportConfiguration::TextureCoordinate:
+        return draco::GeometryAttribute::TEX_COORD;
+    case GLTF2ExportConfiguration::Color:
+        return draco::GeometryAttribute::COLOR;
+    case GLTF2ExportConfiguration::Generic:
+        return draco::GeometryAttribute::GENERIC;
+    }
+    return draco::GeometryAttribute::INVALID;
+}
+} // namespace
+
+CompressedMesh compressMesh(
+        const Qt3DRender::QGeometry &geometry,
+        const GLTF2ExportConfiguration &conf)
+{
+    std::unique_ptr<draco::EncoderBuffer> compressBuffer(new draco::EncoderBuffer);
+    std::vector<std::pair<QString, int>> attributes;
+    draco::Mesh dracoMesh;
+
+    // Convert Qt3D geometry to draco mesh
+    const auto geometryAttributes = geometry.attributes();
+    const Qt3DRender::QAttribute *indicesAttribute = nullptr;
+
+    for (const auto *attribute : geometryAttributes) {
+        if (attribute->name() == Qt3DRender::QAttribute::defaultPositionAttributeName()) {
+            dracoMesh.set_num_points(attribute->count());
+            break;
+        }
+    }
+
+    for (const auto *attribute : geometryAttributes) {
+        if (attribute->attributeType() == Qt3DRender::QAttribute::IndexAttribute) {
+            indicesAttribute = attribute;
+            continue;
+        }
+
+        switch (attribute->vertexBaseType()) {
+        case Qt3DRender::QAttribute::VertexBaseType::Float: {
+            if(!compressAttribute<float>(*attribute, dracoMesh, attributes))
+                return {};
+            break;
+        }
+        case Qt3DRender::QAttribute::VertexBaseType::Byte: {
+            static_assert(CHAR_MIN < 0, "This code only works on platforms with signed char");
+            if(!compressAttribute<char>(*attribute, dracoMesh, attributes))
+                return {};
+            break;
+        }
+        case Qt3DRender::QAttribute::VertexBaseType::UnsignedByte: {
+            if(!compressAttribute<unsigned char>(*attribute, dracoMesh, attributes))
+                return {};
+            break;
+        }
+        case Qt3DRender::QAttribute::VertexBaseType::Short: {
+            if(!compressAttribute<short>(*attribute, dracoMesh, attributes))
+                return {};
+            break;
+        }
+        case Qt3DRender::QAttribute::VertexBaseType::UnsignedShort: {
+            if(!compressAttribute<unsigned short>(*attribute, dracoMesh, attributes))
+                return {};
+            break;
+        }
+        case Qt3DRender::QAttribute::VertexBaseType::Int: {
+            if(!compressAttribute<int>(*attribute, dracoMesh, attributes))
+                return {};
+            break;
+        }
+        case Qt3DRender::QAttribute::VertexBaseType::UnsignedInt: {
+            if(!compressAttribute<unsigned int>(*attribute, dracoMesh, attributes))
+                return {};
+            break;
+        }
+        case Qt3DRender::QAttribute::VertexBaseType::Double: {
+            if(!compressAttribute<double>(*attribute, dracoMesh, attributes))
+                return {};
+            break;
+        }
+        case Qt3DRender::QAttribute::VertexBaseType::HalfFloat:
+        default:
+            qCWarning(dracocompressor) << "Warning: skipping attribute" << attribute->name() << "of unhandled type" << attribute->vertexBaseType();
+            break;
+        }
+    }
+
+    if (indicesAttribute != nullptr) {
+        switch (indicesAttribute->vertexBaseType()) {
+        case Qt3DRender::QAttribute::VertexBaseType::Byte:
+            addFacesToMesh(createIndicesVectorFromAttribute<char>(*indicesAttribute), dracoMesh);
+            break;
+        case Qt3DRender::QAttribute::VertexBaseType::UnsignedByte:
+            addFacesToMesh(createIndicesVectorFromAttribute<unsigned char>(*indicesAttribute), dracoMesh);
+            break;
+        case Qt3DRender::QAttribute::VertexBaseType::Short:
+            addFacesToMesh(createIndicesVectorFromAttribute<short>(*indicesAttribute), dracoMesh);
+            break;
+        case Qt3DRender::QAttribute::VertexBaseType::UnsignedShort:
+            addFacesToMesh(createIndicesVectorFromAttribute<unsigned short>(*indicesAttribute), dracoMesh);
+            break;
+        case Qt3DRender::QAttribute::VertexBaseType::Int:
+            addFacesToMesh(createIndicesVectorFromAttribute<int>(*indicesAttribute), dracoMesh);
+            break;
+        case Qt3DRender::QAttribute::VertexBaseType::UnsignedInt:
+            addFacesToMesh(createIndicesVectorFromAttribute<unsigned int>(*indicesAttribute), dracoMesh);
+            break;
+        default:
+            break;
+        }
+    }
+
+    draco::Encoder encoder;
+
+    auto setQuantization = [&](GLTF2ExportConfiguration::MeshAttribute attr) {
+        int q = conf.attributeQuantizationLevel(attr);
+        if (q > 0)
+            encoder.SetAttributeQuantization(dracoAttribute(attr), q);
+    };
+    setQuantization(GLTF2ExportConfiguration::Position);
+    setQuantization(GLTF2ExportConfiguration::Normal);
+    setQuantization(GLTF2ExportConfiguration::Color);
+    setQuantization(GLTF2ExportConfiguration::TextureCoordinate);
+    setQuantization(GLTF2ExportConfiguration::Generic);
+
+    encoder.SetSpeedOptions(conf.meshEncodingSpeed(), conf.meshDecodingSpeed());
+
+    encoder.SetTrackEncodedProperties(true);
+    const auto status = encoder.EncodeMeshToBuffer(dracoMesh, compressBuffer.get());
+    if (!status.ok()) {
+        qCWarning(dracocompressor) << status.code() << status.error_msg();
+        return {};
+    }
+
+    return { std::move(compressBuffer), attributes };
+}
+
+} // namespace DracoCompression
+} // namespace Kuesa
+QT_END_NAMESPACE

--- a/src/core/gltf2exporter/dracocompressor_p.h
+++ b/src/core/gltf2exporter/dracocompressor_p.h
@@ -1,0 +1,69 @@
+/*
+    dracocompressor_p.h
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Juan Jose Casafranca <juan.casafranca@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef KUESA_GLTF2EXPORTER_DRACOCOMPRESSOR_P_H
+#define KUESA_GLTF2EXPORTER_DRACOCOMPRESSOR_P_H
+
+//
+//  NOTICE
+//  ------
+//
+// We mean it: this file is not part of the public API and could be
+// modified without notice
+//
+
+#include <draco/compression/encode.h>
+#include <memory>
+#include <vector>
+#include <QString>
+
+namespace draco {
+class EncoderBuffer;
+}
+
+QT_BEGIN_NAMESPACE
+
+namespace Qt3DRender {
+class QGeometry;
+}
+namespace Kuesa {
+class GLTF2ExportConfiguration;
+namespace DracoCompression {
+
+struct CompressedMesh {
+    std::unique_ptr<draco::EncoderBuffer> buffer;
+    std::vector<std::pair<QString, int>> attributes;
+};
+
+CompressedMesh compressMesh(const Qt3DRender::QGeometry &geometry, const GLTF2ExportConfiguration &);
+} // namespace DracoCompression
+} // namespace Kuesa
+
+QT_END_NAMESPACE
+
+#endif // KUESA_GLTF2EXPORTER_DRACOCOMPRESSOR_H

--- a/src/core/gltf2exporter/gltf2exporter.pri
+++ b/src/core/gltf2exporter/gltf2exporter.pri
@@ -1,9 +1,9 @@
-# auto.pro
+# gltf2exporter.pri
 #
 # This file is part of Kuesa.
 #
-# Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-# Author: Mike Krus <mike.krus@kdab.com>
+# Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 #
 # Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
 # accordance with the Kuesa Enterprise License Agreement provided with the Software in the
@@ -24,41 +24,21 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-TEMPLATE = subdirs
+INCLUDEPATH += $$PWD
 
-SUBDIRS = \
-#    cmake \
-    assetcollection \
-    meshcollection \
-    texturecollection \
-    skeletoncollection \
-    animationclipcollection \
-    effectcollection \
-    sceneentity \
-    textureimagecollection \
-    assetpipelineeditor
+SOURCES += \
+    $$PWD/gltf2exporter_p.cpp
 
-#installed_cmake.depends = cmake
 
-qtConfig(private_tests) {
-    SUBDIRS += \
-        bufferparser \
-        bufferviewparser \
-        bufferaccessorparser \
-        cameraparser \
-        meshparser \
-        nodeparser \
-        gltfparser \
-        gltfexporter \
-        layerparser \
-        imageparser \
-        texturesamplerparser \
-        textureparser \
-        animationparser \
-        sceneparser \
-        materialparser \
-        skinparser \
-        postfxlistextension \
-        assetitem \
-        forwardrenderer
+HEADERS += \
+    $$PWD/gltf2exporter_p.h
+
+qtConfig(kuesa-draco) {
+    DEFINES += KUESA_DRACO_COMPRESSION
+    LIBS += -ldraco -ldracodec
+
+    SOURCES += \
+      $$PWD/dracocompressor_p.cpp
+    HEADERS +=\
+      $$PWD/dracocompressor_p.h
 }

--- a/src/core/gltf2exporter/gltf2exporter_p.cpp
+++ b/src/core/gltf2exporter/gltf2exporter_p.cpp
@@ -1,0 +1,736 @@
+﻿/*
+    gltf2exporter_p.cpp
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <draco/compression/encode.h>
+#if defined(KUESA_DRACO_COMPRESSION)
+#include "dracocompressor_p.h"
+#endif
+
+#include <QFile>
+#include <SceneEntity>
+#include "gltf2exporter_p.h"
+#include "gltf2context_p.h"
+#include "gltf2keys_p.h"
+#include "gltf2importer.h"
+#include "kuesa_p.h"
+#include <set>
+#include <Kuesa/private/gltf2context_p.h>
+
+QT_BEGIN_NAMESPACE
+
+namespace Qt3DRender {
+class QGeometryRenderer;
+class QGeometry;
+} // namespace Qt3DRender
+
+namespace Kuesa {
+namespace {
+QString generateUniqueFilename(const QDir& dir, QString filename)
+{
+    QFileInfo fi(filename);
+    auto basename = fi.baseName();
+    auto ext = fi.completeSuffix();
+    int num = 1;
+    while(dir.exists(filename))
+    {
+        filename = basename + "-" + QString::number(num) + "." + ext;
+    }
+    return filename;
+}
+}
+
+void GLTF2ExportConfiguration::setMeshEncodingSpeed(int speed)
+{
+    if (speed >= 0 && speed <= 10)
+        m_encodingSpeed = speed;
+}
+
+void GLTF2ExportConfiguration::setMeshDecodingSpeed(int speed)
+{
+    if (speed >= 0 && speed <= 10)
+        m_decodingSpeed = speed;
+}
+
+int GLTF2ExportConfiguration::meshEncodingSpeed() const
+{
+    return m_encodingSpeed;
+}
+
+int GLTF2ExportConfiguration::meshDecodingSpeed() const
+{
+    return m_decodingSpeed;
+}
+
+void GLTF2ExportConfiguration::setAttributeQuantizationLevel(
+        GLTF2ExportConfiguration::MeshAttribute attribute,
+        int level)
+{
+    if (level >= 0 && level <= 10)
+        m_quantization[attribute] = level;
+}
+
+int GLTF2ExportConfiguration::attributeQuantizationLevel(
+        GLTF2ExportConfiguration::MeshAttribute attribute) const
+{
+    auto it = m_quantization.find(attribute);
+    if (it != m_quantization.end()) {
+        return it.value();
+    }
+    return 0;
+}
+
+void GLTF2ExportConfiguration::setMeshCompressionEnabled(bool enabled)
+{
+    m_meshCompression = enabled;
+}
+
+bool GLTF2ExportConfiguration::meshCompressionEnabled() const
+{
+    return m_meshCompression;
+}
+
+namespace {
+#if defined(KUESA_DRACO_COMPRESSION)
+class GLTF2DracoCompressor
+{
+public:
+    GLTF2DracoCompressor(
+            QDir source,
+            QDir destination,
+            const QJsonObject &rootObject,
+            const GLTF2ExportConfiguration &conf,
+            const GLTF2Import::GLTF2Context &context)
+        : m_root(rootObject)
+        , m_buffers(rootObject[GLTF2Import::KEY_BUFFERS].toArray())
+        , m_bufferViews(rootObject[GLTF2Import::KEY_BUFFERVIEWS].toArray())
+        , m_accessors(rootObject[GLTF2Import::KEY_ACCESSORS].toArray())
+        , m_meshes(rootObject[GLTF2Import::KEY_MESHES].toArray())
+        , m_images(rootObject[GLTF2Import::KEY_IMAGES].toArray())
+        , m_compressedBufferIndex(m_buffers.size()) // Indice of the added buffer
+        , m_newBufferViewIndex(m_bufferViews.size()) // Indice of where the bufferView are added
+        , m_basePath(source)
+        , m_destination(destination)
+        , m_conf(conf)
+        , m_context(context)
+    {
+    }
+
+    QJsonObject compress()
+    {
+        // https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md
+
+        // 1. Compress all the meshes
+        for (int i = 0, n = m_context.meshesCount(); i < n; i++) {
+            const auto mesh_json = m_meshes[i].toObject();
+            m_meshes[i] = compressMesh(mesh_json, i);
+        }
+
+        if (m_compressedBuffer.isEmpty()) {
+            return m_root; // Nothing changed
+        }
+
+        // 2. Save all the compressed data in a monolithic buffer and add it to the buffer list
+        {
+
+            const auto defaultCompressedBufferFile = generateUniqueFilename(m_basePath, QStringLiteral("compressedBuffer.bin"));
+
+            // TODO maybe warn the user of unused assets ?
+            QFile compressedBufferFile(m_destination.filePath({ defaultCompressedBufferFile }));
+            if (compressedBufferFile.open(QIODevice::WriteOnly)) {
+                compressedBufferFile.write(m_compressedBuffer);
+                compressedBufferFile.close();
+            } else {
+                m_errors << QStringLiteral("Could not open %1 for writing.").arg(compressedBufferFile.fileName());
+                return {};
+            }
+
+            QJsonObject compressedBufferObject;
+            compressedBufferObject[GLTF2Import::KEY_BYTELENGTH] = m_compressedBuffer.size();
+            compressedBufferObject[GLTF2Import::KEY_URI] = defaultCompressedBufferFile;
+            m_buffers.push_back(compressedBufferObject);
+        }
+
+        // 3. Adjust the accessors: they don't need to point to a bufferView anymore since it's the Draco extension which is aware of them
+        // TODO what happens if an accessor was referred by a mesh but also something else ?
+        std::set<int> bufferViews_to_clean = cleanAccessors(m_accessors, m_accessorsToClean);
+
+        // 4. Remove the data from the buffers and adjust the remaining bufferViews
+        // We have to update *all* the indices everywhere - not only for meshes.
+        removeBufferViews(bufferViews_to_clean);
+
+        // 5. Finalize the JSON
+        auto replace_json = [&](QJsonObject &m_root, const QLatin1String &k, QJsonArray &arr) {
+            auto it = m_root.find(k);
+            if (it != m_root.end() && arr.empty())
+                m_root.erase(it);
+            else if (!arr.empty())
+                *it = std::move(arr);
+        };
+        replace_json(m_root, GLTF2Import::KEY_BUFFERS, m_buffers);
+        replace_json(m_root, GLTF2Import::KEY_BUFFERVIEWS, m_bufferViews);
+        replace_json(m_root, GLTF2Import::KEY_ACCESSORS, m_accessors);
+        replace_json(m_root, GLTF2Import::KEY_MESHES, m_meshes);
+        replace_json(m_root, GLTF2Import::KEY_IMAGES, m_images);
+
+        addExtension(m_root, GLTF2Import::KEY_EXTENSIONS_REQUIRED, GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION);
+        addExtension(m_root, GLTF2Import::KEY_EXTENSIONS_USED, GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION);
+
+        return m_root;
+    }
+
+private:
+    struct CompressedGLTFPrimitive {
+        QJsonObject primitiveJson;
+        QByteArray compressedData;
+        QJsonObject newBufferView;
+        std::set<int> accessorsToClean;
+    };
+
+    QStringList m_errors;
+
+    QJsonObject m_root;
+    QJsonArray m_buffers;
+    QJsonArray m_bufferViews;
+    QJsonArray m_accessors;
+    QJsonArray m_meshes;
+    QJsonArray m_images;
+
+    QByteArray m_compressedBuffer;
+    const int m_compressedBufferIndex;
+    int m_newBufferViewIndex;
+    std::set<int> m_accessorsToClean;
+    QDir m_basePath, m_destination;
+
+    const GLTF2ExportConfiguration &m_conf;
+    const GLTF2Import::GLTF2Context &m_context;
+
+    // Compress a single mesh
+    QJsonObject compressMesh(QJsonObject mesh_json, int mesh_idx)
+    {
+        const auto &primitives = m_context.mesh(mesh_idx).meshPrimitives;
+        auto primitives_json = mesh_json[GLTF2Import::KEY_PRIMITIVES].toArray();
+
+        Q_ASSERT_X(primitives_json.size() == primitives.size(), "GLTF2DracoCompressor::compressMesh", "Bad primitive count");
+
+        for (int p = 0; p < primitives_json.size(); ++p) {
+            auto primitive_json = primitives_json[p].toObject();
+
+            // First check if the primitive is already draco-compressed
+            auto ext_it = primitive_json.find(GLTF2Import::KEY_EXTENSIONS);
+            if (ext_it != primitive_json.end()) {
+                auto ext = ext_it->toObject();
+                if (ext.contains(GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION)) {
+                    continue;
+                }
+            }
+
+            auto compressed_mesh = compressPrimitive(
+                    primitive_json,
+                    primitives[p]);
+
+            if (!compressed_mesh.primitiveJson.empty()) {
+                //* all the side-effects of this method are in this block: */
+                primitives_json[p] = compressed_mesh.primitiveJson;
+                m_compressedBuffer.push_back(compressed_mesh.compressedData);
+                m_bufferViews.push_back(compressed_mesh.newBufferView);
+                m_accessorsToClean.insert(compressed_mesh.accessorsToClean.begin(), compressed_mesh.accessorsToClean.end());
+
+                m_newBufferViewIndex++;
+            } else {
+                const auto meshName = mesh_json[GLTF2Import::KEY_NAME].toString();
+                if (!meshName.isEmpty())
+                    m_errors << QStringLiteral("A mesh could not be compressed: %1 -> %2").arg(meshName).arg(p);
+                else
+                    m_errors << QStringLiteral("A mesh could not be compressed: %1 -> %2").arg(mesh_idx).arg(p);
+            }
+        }
+
+        mesh_json[GLTF2Import::KEY_PRIMITIVES] = std::move(primitives_json);
+        return mesh_json;
+    }
+
+    // Compress a single primitive of a mesh
+    CompressedGLTFPrimitive compressPrimitive(
+            QJsonObject primitive_json, const Kuesa::GLTF2Import::Primitive &primitive) const
+    {
+        CompressedGLTFPrimitive compressed_primitive;
+
+        // Do the compression
+        const auto compressed = Kuesa::DracoCompression::compressMesh(*primitive.primitiveRenderer->geometry(), m_conf);
+        if (!compressed.buffer)
+            return {};
+
+        const int offset = m_compressedBuffer.size();
+        auto &eb = *compressed.buffer.get();
+        const int eb_size = static_cast<int>(eb.size());
+
+        compressed_primitive.compressedData = QByteArray{ eb.data(), eb_size };
+
+        // For now we allocate new bufferViews per compressed chunk; then we should do a pass to remove / replace unused bv ?
+
+        // Allocate a new buffer view
+        {
+            compressed_primitive.newBufferView[GLTF2Import::KEY_BUFFER] = m_compressedBufferIndex;
+            compressed_primitive.newBufferView[GLTF2Import::KEY_BYTEOFFSET] = offset;
+            compressed_primitive.newBufferView[GLTF2Import::KEY_BYTELENGTH] = eb_size;
+        }
+
+        // Create or modify the extension object
+        {
+            auto ext_obj = primitive_json[GLTF2Import::KEY_EXTENSIONS].toObject();
+
+            {
+                QJsonObject draco_ext;
+                draco_ext[GLTF2Import::KEY_BUFFERVIEW] = m_newBufferViewIndex;
+                {
+                    QJsonObject draco_ext_attr;
+                    for (const auto &attribute : compressed.attributes) {
+                        draco_ext_attr[attribute.first] = attribute.second;
+                    }
+                    draco_ext[GLTF2Import::KEY_ATTRIBUTES] = draco_ext_attr;
+                }
+
+                ext_obj[GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION] = draco_ext;
+            }
+
+            primitive_json[GLTF2Import::KEY_EXTENSIONS] = ext_obj;
+        }
+
+        // Mark the primitive's accessors
+        {
+            auto it = primitive_json.find(GLTF2Import::KEY_INDICES);
+            if (it != primitive_json.end() && it->isDouble()) {
+                compressed_primitive.accessorsToClean.insert(it->toInt());
+            }
+
+            it = primitive_json.find(GLTF2Import::KEY_ATTRIBUTES);
+            if (it != primitive_json.end() && it->isObject()) {
+                const auto attributes = it->toObject();
+                for (const auto &attr : attributes) {
+                    if (attr.isDouble())
+                        compressed_primitive.accessorsToClean.insert(attr.toInt());
+                }
+            }
+        }
+        compressed_primitive.primitiveJson = primitive_json;
+
+        return compressed_primitive;
+    }
+
+    void removeBufferViews(const std::set<int> &indicesToRemove)
+    {
+        // First compute the new indices of the buffer views
+        std::map<int, int> bufferViewIndex;
+        int currentOffset = 0;
+        for (int i = 0, n = m_bufferViews.size(); i < n; i++) {
+            if (indicesToRemove.count(i) != 0) {
+                currentOffset++;
+            }
+            bufferViewIndex[i] = i - currentOffset;
+        }
+
+        auto updateExistingIndex = [&](QJsonObject &obj, const QLatin1String &key) {
+            auto it = obj.find(key);
+            if (it != obj.end()) {
+                it.value() = bufferViewIndex.at(it.value().toInt());
+            }
+        };
+
+        // Fix them in the accessors
+        for (int i = 0; i < m_accessors.size(); i++) {
+            auto acc = m_accessors[i].toObject();
+
+            updateExistingIndex(acc, GLTF2Import::KEY_BUFFERVIEW);
+
+            {
+                auto it = acc.find(GLTF2Import::KEY_SPARSE);
+                if (it != acc.end()) {
+                    auto sparse = it->toObject();
+                    {
+                        auto indices = sparse.value(GLTF2Import::KEY_INDICES).toObject();
+                        updateExistingIndex(indices, GLTF2Import::KEY_BUFFERVIEW);
+                        sparse[GLTF2Import::KEY_INDICES] = std::move(indices);
+                    }
+                    {
+                        auto values = sparse.value(GLTF2Import::KEY_VALUES).toObject();
+                        updateExistingIndex(values, GLTF2Import::KEY_BUFFERVIEW);
+                        sparse[GLTF2Import::KEY_VALUES] = std::move(values);
+                    }
+                    *it = std::move(sparse);
+                }
+            }
+
+            m_accessors[i] = std::move(acc);
+        }
+
+        // Fix them in the meshes
+        for (int i = 0; i < m_meshes.size(); i++) {
+            auto mesh = m_meshes[i].toObject();
+            auto primitives = mesh[GLTF2Import::KEY_PRIMITIVES].toArray();
+            for (int p = 0; p < primitives.size(); p++) {
+                auto primitive = primitives[p].toObject();
+
+                auto ext_it = primitive.find(GLTF2Import::KEY_EXTENSIONS);
+                if (ext_it != primitive.end()) {
+                    auto ext = ext_it->toObject();
+
+                    auto draco_it = ext.find(GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION);
+                    if (draco_it != ext.end()) {
+                        auto draco = draco_it->toObject();
+                        updateExistingIndex(draco, GLTF2Import::KEY_BUFFERVIEW);
+                        *draco_it = std::move(draco);
+                    }
+
+                    *ext_it = std::move(ext);
+                }
+
+                primitives[p] = std::move(primitive);
+            }
+            mesh[GLTF2Import::KEY_PRIMITIVES] = std::move(primitives);
+            m_meshes[i] = std::move(mesh);
+        }
+
+        // Fix them in the images
+        for (int i = 0; i < m_images.size(); i++) {
+            auto img = m_images[i].toObject();
+            updateExistingIndex(img, GLTF2Import::KEY_BUFFERVIEW);
+            m_images[i] = std::move(img);
+        }
+
+        // Remove the buffer views
+        QJsonArray removedBufferViews;
+        // (note: this loop could be merged with the earlier one
+        // but this would be a bit less readable imho)
+        for (auto it = indicesToRemove.rbegin(); it != indicesToRemove.rend(); ++it) {
+            auto bv_it = m_bufferViews.begin() + (*it);
+
+            removedBufferViews.push_back(std::move(*bv_it));
+            m_bufferViews.erase(bv_it);
+        }
+
+        cleanupBuffers(removedBufferViews);
+    }
+
+    struct BufferParts {
+        int offset{};
+        int length{};
+        int stride{};
+        friend bool operator==(const BufferParts &lhs, const BufferParts &rhs)
+        {
+            return lhs.offset == rhs.offset;
+        }
+        friend bool operator<(const BufferParts &lhs, const BufferParts &rhs)
+        {
+            return lhs.offset < rhs.offset;
+        }
+    };
+
+    // Maps the new index of an offset in a buffer after removal of prior parts
+    static int mapBufferOffset(const std::set<BufferParts> &removed_parts, int offset)
+    {
+        const auto compare = [](const BufferParts &lhs, int rhs) { return lhs.offset < rhs; };
+        const auto end = std::lower_bound(
+                removed_parts.begin(), removed_parts.end(), offset, compare);
+
+        for (auto it = removed_parts.begin(); it != end; ++it) {
+            offset -= it->length;
+        }
+
+        return offset;
+    }
+
+    // Removes the unused data in buffers
+    void cleanupBuffers(const QJsonArray &removedBufferViews)
+    {
+        std::map<int, std::set<BufferParts>> bufferParts;
+        // List and order all the parts of the buffers to remove
+        for (const QJsonValue &bv_value : removedBufferViews) {
+            auto bv = bv_value.toObject();
+            auto it = bv.find(GLTF2Import::KEY_BUFFER);
+            if (it != bv.end()) {
+                const int buffer_idx = it.value().toInt();
+                const auto buf = m_buffers[buffer_idx].toObject();
+                const auto uri = buf[GLTF2Import::KEY_URI].toString();
+
+                if (QFileInfo::exists(m_basePath.absoluteFilePath(uri))) {
+                    BufferParts p;
+                    p.offset = bv[GLTF2Import::KEY_BYTEOFFSET].toInt();
+                    p.length = bv[GLTF2Import::KEY_BYTELENGTH].toInt();
+                    p.stride = bv[GLTF2Import::KEY_BYTESTRIDE].toInt();
+
+                    bufferParts[buffer_idx].insert(p);
+                } else {
+                    m_errors << QStringLiteral("File does not exist: %1").arg(uri);
+                    // TODO Maybe we should download it and strip the downloaded asset
+                    // There's also the base64 case
+                }
+            }
+        }
+
+        // Remove the parts in the buffers
+        std::vector<int> buffersToRemove;
+
+        // TODO we should check that all buffer objects map to a unique file
+        // else this won't work at all
+        for (const auto &buffer : bufferParts) {
+            QJsonObject buf = m_buffers[buffer.first].toObject();
+
+            auto uri = buf[GLTF2Import::KEY_URI].toString();
+            QFile source_f(m_basePath.absoluteFilePath(uri));
+            if (!source_f.open(QIODevice::ReadOnly)) {
+                m_errors << QStringLiteral("Could not open %1 for reading").arg(source_f.fileName());
+                continue;
+            }
+            QByteArray data = source_f.readAll();
+            source_f.close();
+
+            int removed_length = 0;
+
+            // TODO handle overlapping bufferViews
+            // TODO handle strided buffers
+            for (auto it = buffer.second.rbegin(); it != buffer.second.rend(); ++it) {
+                data.remove(it->offset, it->length);
+                removed_length += it->length;
+            }
+
+            if (data.isEmpty()) {
+                // Actually we could precompute this case...
+                buffersToRemove.push_back(buffer.first);
+            } else {
+                QDir{}.mkpath(QFileInfo(m_destination, uri).absolutePath());
+                QFile target_f(m_destination.filePath(uri));
+                if (!target_f.open(QIODevice::WriteOnly)) {
+                    m_errors << QStringLiteral("Could not open %1 for writing").arg(target_f.fileName());
+                    continue;
+                }
+                target_f.write(data);
+
+                const auto len_it = buf.find(GLTF2Import::KEY_BYTELENGTH);
+                if (len_it != buf.end()) {
+                    (*len_it) = len_it->toInt() - removed_length;
+                }
+
+                m_buffers[buffer.first] = std::move(buf);
+            }
+        }
+
+        // Change the offsets in the bufferViews
+        for (auto bv_it = m_bufferViews.begin(); bv_it != m_bufferViews.end(); ++bv_it) {
+            auto bv = bv_it->toObject();
+            auto it = bv.find(GLTF2Import::KEY_BUFFER);
+            if (it != bv.end()) {
+                const int buffer_idx = it.value().toInt();
+
+                // Change the offset of the data in the buffer
+                auto offset_it = bv.find(GLTF2Import::KEY_BYTEOFFSET);
+                (*offset_it) = mapBufferOffset(bufferParts[buffer_idx], offset_it->toInt());
+
+                // Change the buffer index if there are removed buffers
+                int new_buffer_idx = buffer_idx;
+                for (int removed_buf : buffersToRemove) {
+                    if (removed_buf < buffer_idx)
+                        new_buffer_idx--;
+                    else
+                        break;
+                }
+                (*it) = new_buffer_idx;
+                (*bv_it) = std::move(bv);
+            }
+        }
+
+        // Remove unused buffers
+        for (int buffer : buffersToRemove) {
+            m_buffers.erase(m_buffers.begin() + buffer);
+        }
+
+        // TODO Do a final pass to check if there are any unreferenced buffers
+        // Or it could maybe be an additional "lint" pass not part of the draco one ?
+    }
+
+    // Add an extension if it is not already registered - this could be moved at a more generic place
+    // if further extensions are to be added
+    static void addExtension(QJsonObject &rootObject, const QString &where, const QString &extension)
+    {
+        auto extensions = rootObject[where].toArray();
+        auto ext_it = std::find_if(extensions.begin(), extensions.end(), [&](const QJsonValue &v) {
+            return v.toString() == extension;
+        });
+
+        if (ext_it == extensions.end()) {
+            extensions.push_back(extension);
+            rootObject[where] = std::move(extensions);
+        }
+    }
+
+    // Given an accessor array, remove their "bufferView": key, and return the corresponding set of
+    // bufferViews
+    static std::set<int> cleanAccessors(QJsonArray &accessors, const std::set<int> &indices)
+    {
+        std::set<int> bufferViews;
+        for (int accessor : indices) {
+            auto acc = accessors[accessor].toObject();
+            auto it = acc.find(GLTF2Import::KEY_BUFFERVIEW);
+            if (it != acc.end()) {
+                bufferViews.insert(it.value().toInt());
+                acc.erase(it);
+
+                acc.remove(GLTF2Import::KEY_BYTEOFFSET);
+            }
+            accessors[accessor] = std::move(acc);
+        }
+        return bufferViews;
+    }
+};
+#endif
+
+} // namespace
+
+GLTF2Exporter::GLTF2Exporter(QObject *parent)
+    : QObject(parent)
+{
+}
+
+SceneEntity *GLTF2Exporter::scene() const
+{
+    return m_scene;
+}
+
+QStringList GLTF2Exporter::errors() const
+{
+    return m_errors;
+}
+
+GLTF2ExportConfiguration GLTF2Exporter::configuration() const
+{
+    return m_conf;
+}
+
+void GLTF2Exporter::setConfiguration(const GLTF2ExportConfiguration &conf)
+{
+    m_conf = std::move(conf);
+}
+
+void GLTF2Exporter::setContext(GLTF2Import::GLTF2Context *context)
+{
+    m_context = context;
+}
+
+void GLTF2Exporter::setContextFromImporter(GLTF2Importer *importer)
+{
+    m_context = importer->m_context;
+}
+
+QJsonObject GLTF2Exporter::saveInFolder(
+        const QDir &source,
+        const QDir &target)
+{
+    m_errors.clear();
+    if (!m_context) {
+        m_errors << QLatin1String("Tried to save GLTF without a context");
+        return {};
+    }
+
+    if (!QFileInfo(target.absolutePath()).isWritable()) {
+        m_errors << QStringLiteral("Cannot write to output directory %1").arg(target.absolutePath());
+        return {};
+    }
+
+    QJsonObject rootObject = m_context->json().object();
+    if (rootObject.isEmpty()) {
+        m_errors << QStringLiteral("Nothing to save");
+        return {};
+    }
+
+#if defined(KUESA_DRACO_COMPRESSION)
+    if (m_conf.meshCompressionEnabled()) {
+        GLTF2DracoCompressor compressor(source, target, rootObject, m_conf, *m_context);
+        rootObject = compressor.compress();
+        if (rootObject.empty()) {
+            m_errors << QStringLiteral("Draco compression failed");
+            return {};
+        }
+    }
+#endif
+
+    if (source != target) {
+        // Copy buffers
+        auto buffers_it = rootObject.find(GLTF2Import::KEY_BUFFERS);
+        if (buffers_it != rootObject.end()) {
+            copyURIs(source, target, buffers_it->toArray());
+        };
+
+        // Copy images
+        auto images_it = rootObject.find(GLTF2Import::KEY_IMAGES);
+        if (images_it != rootObject.end()) {
+            copyURIs(source, target, images_it->toArray());
+        }
+    }
+
+    return rootObject;
+}
+
+// Copies all the files referenced in an array of GLTF objects
+void GLTF2Exporter::copyURIs(const QDir &source, const QDir &target, const QJsonArray &array)
+{
+    for (const auto &val : array) {
+        const auto &buffer = val.toObject();
+        auto uri_it = buffer.find(GLTF2Import::KEY_URI);
+        if (uri_it == buffer.end())
+            return;
+
+        QFile srcFile(source.absoluteFilePath(uri_it->toString()));
+        const QFileInfo destFile(target, uri_it->toString());
+
+        if (!destFile.exists()) {
+            if (srcFile.exists()) {
+                // Copy files from the source to the target directory
+                QDir{}.mkpath(destFile.absolutePath());
+
+                bool ok = srcFile.copy(target.absoluteFilePath(uri_it->toString()));
+                if (!ok) {
+                    m_errors << QStringLiteral("Unable to copy %1").arg(uri_it->toString());
+                }
+            } else {
+                m_errors << QStringLiteral("Tried to copy missing file %1").arg(uri_it->toString());
+            }
+        }
+    }
+}
+
+void GLTF2Exporter::setScene(SceneEntity *scene)
+{
+    if (m_scene == scene)
+        return;
+
+    m_scene = scene;
+    emit sceneChanged(m_scene);
+}
+
+} // namespace Kuesa
+
+QT_END_NAMESPACE

--- a/src/core/gltf2exporter/gltf2exporter_p.h
+++ b/src/core/gltf2exporter/gltf2exporter_p.h
@@ -1,0 +1,126 @@
+/*
+    gltf2exporter_p.h
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef KUESA_GLTF2EXPORTER_GLTF2EXPORTER_P_H
+#define KUESA_GLTF2EXPORTER_GLTF2EXPORTER_P_H
+
+//
+//  NOTICE
+//  ------
+//
+// We mean it: this file is not part of the public API and could be
+// modified without notice
+//
+
+#include <QObject>
+#include <QUrl>
+#include <QDir>
+#include <QJsonObject>
+#include <QMap>
+#include <Kuesa/kuesa_global.h>
+#include <Kuesa/private/kuesa_global_p.h>
+
+QT_BEGIN_NAMESPACE
+
+namespace Kuesa {
+class GLTF2Importer;
+namespace GLTF2Import {
+class GLTF2Context;
+}
+class SceneEntity;
+
+class KUESA_PRIVATE_EXPORT GLTF2ExportConfiguration
+{
+public:
+    enum MeshAttribute {
+        Position,
+        Normal,
+        Color,
+        TextureCoordinate,
+        Generic
+    };
+
+    // O = slowest, 10 = fastest
+    void setMeshEncodingSpeed(int speed);
+    int meshEncodingSpeed() const;
+    void setMeshDecodingSpeed(int speed);
+    int meshDecodingSpeed() const;
+
+    void setAttributeQuantizationLevel(MeshAttribute attribute, int level);
+    int attributeQuantizationLevel(MeshAttribute) const;
+
+    void setMeshCompressionEnabled(bool enabled);
+    bool meshCompressionEnabled() const;
+
+private:
+    int m_encodingSpeed{};
+    int m_decodingSpeed{};
+    bool m_meshCompression{};
+    QMap<MeshAttribute, int> m_quantization;
+};
+
+class KUESA_PRIVATE_EXPORT GLTF2Exporter : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(SceneEntity *scene READ scene WRITE setScene NOTIFY sceneChanged)
+
+public:
+    explicit GLTF2Exporter(QObject *parent = nullptr);
+
+    SceneEntity *scene() const;
+    QStringList errors() const;
+
+    GLTF2ExportConfiguration configuration() const;
+    void setConfiguration(const GLTF2ExportConfiguration &conf);
+
+    void setContext(GLTF2Import::GLTF2Context *context);
+    void setContextFromImporter(GLTF2Importer *importer);
+
+Q_SIGNALS:
+    void sceneChanged(SceneEntity *scene);
+
+public Q_SLOTS:
+    void setScene(SceneEntity *scene);
+
+    QJsonObject saveInFolder(
+            const QDir &sourceFolder,
+            const QDir &targetFolder);
+
+private:
+    void copyURIs(const QDir &source, const QDir &target, const QJsonArray &array);
+
+    GLTF2Import::GLTF2Context *m_context;
+    SceneEntity *m_scene;
+
+    GLTF2ExportConfiguration m_conf;
+    QStringList m_errors;
+};
+} // namespace Kuesa
+QT_END_NAMESPACE
+
+#endif // KUESA_GLTF2EXPORTER_GLTF2EXPORTER_H

--- a/src/core/gltf2importer/gltf2context.cpp
+++ b/src/core/gltf2importer/gltf2context.cpp
@@ -340,6 +340,16 @@ void GLTF2Context::setRequiredExtensions(const QStringList &requiredExtensions)
     m_requiredExtensions = requiredExtensions;
 }
 
+const QJsonDocument &GLTF2Context::json() const
+{
+    return m_json;
+}
+
+void GLTF2Context::setJson(const QJsonDocument &doc)
+{
+    m_json = doc;
+}
+
 template<>
 int GLTF2Context::count<Mesh>() const
 {

--- a/src/core/gltf2importer/gltf2context_p.h
+++ b/src/core/gltf2importer/gltf2context_p.h
@@ -38,6 +38,7 @@
 //
 
 #include <QVector>
+#include <QJsonDocument>
 #include "bufferparser_p.h"
 #include "bufferviewsparser_p.h"
 #include "cameraparser_p.h"
@@ -142,6 +143,9 @@ public:
     QStringList requiredExtensions() const;
     void setRequiredExtensions(const QStringList &requiredExtensions);
 
+    const QJsonDocument &json() const;
+    void setJson(const QJsonDocument &doc);
+
 private:
     QVector<Accessor> m_accessors;
     QVector<QByteArray> m_buffers;
@@ -159,6 +163,7 @@ private:
     QVector<Skin> m_skins;
     QStringList m_usedExtensions;
     QStringList m_requiredExtensions;
+    QJsonDocument m_json;
 };
 
 template<>

--- a/src/core/gltf2importer/gltf2importer.h
+++ b/src/core/gltf2importer/gltf2importer.h
@@ -37,6 +37,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Kuesa {
 class SceneEntity;
+class GLTF2Exporter;
 namespace GLTF2Import {
 class GLTF2Context;
 }
@@ -82,6 +83,8 @@ private Q_SLOTS:
 private:
     void clear();
     void setStatus(Status status);
+
+    friend class GLTF2Exporter;
 
     Kuesa::GLTF2Import::GLTF2Context *m_context;
     QUrl m_source;

--- a/src/core/gltf2importer/gltf2importer.pri
+++ b/src/core/gltf2importer/gltf2importer.pri
@@ -45,6 +45,7 @@ SOURCES += \
     $$PWD/materialparser.cpp \
     $$PWD/skinparser.cpp
 
+
 HEADERS += \
     $$PWD/bufferparser_p.h \
     $$PWD/bufferviewsparser_p.h \
@@ -62,9 +63,11 @@ HEADERS += \
     $$PWD/animationparser_p.h \
     $$PWD/sceneparser_p.h \
     $$PWD/materialparser_p.h \
-    $$PWD/skinparser_p.h
+    $$PWD/skinparser_p.h \
+    $$PWD/gltf2keys_p.h
 
 qtConfig(kuesa-draco) {
     DEFINES += KUESA_DRACO_COMPRESSION
     LIBS += -ldraco -ldracodec
+
 }

--- a/src/core/gltf2importer/gltf2keys_p.h
+++ b/src/core/gltf2importer/gltf2keys_p.h
@@ -1,0 +1,88 @@
+/*
+    gltf2keys_p.h
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef KUESA_GLTF2IMPORT_GLTF2KEYS_P_H
+#define KUESA_GLTF2IMPORT_GLTF2KEYS_P_H
+
+//
+//  NOTICE
+//  ------
+//
+// We mean it: this file is not part of the public API and could be
+// modified without notice
+//
+
+#include <QtCore/qglobal.h>
+#include <QtCore/QString>
+
+QT_BEGIN_NAMESPACE
+namespace Kuesa {
+namespace GLTF2Import {
+
+const QLatin1String KEY_BUFFERS = QLatin1Literal("buffers");
+const QLatin1String KEY_BUFFERVIEWS = QLatin1Literal("bufferViews");
+const QLatin1String KEY_ACCESSORS = QLatin1Literal("accessors");
+const QLatin1String KEY_NODES = QLatin1Literal("nodes");
+const QLatin1String KEY_MESHES = QLatin1Literal("meshes");
+const QLatin1String KEY_SCENE = QLatin1Literal("scene");
+const QLatin1String KEY_SCENES = QLatin1Literal("scenes");
+const QLatin1String KEY_KDAB_KUESA_LAYER_EXTENSION = QLatin1String("KDAB_Kuesa_Layers");
+const QLatin1String KEY_MSFT_DDS_EXTENSION = QLatin1String("MSFT_texture_dds");
+const QLatin1String KEY_KUESA_LAYERS = QLatin1Literal("layers");
+const QLatin1String KEY_CAMERAS = QLatin1Literal("cameras");
+const QLatin1String KEY_IMAGES = QLatin1Literal("images");
+const QLatin1String KEY_TEXTURE_SAMPLERS = QLatin1Literal("samplers");
+const QLatin1String KEY_TEXTURES = QLatin1String("textures");
+const QLatin1String KEY_EXTENSIONS = QLatin1String("extensions");
+const QLatin1String KEY_EXTENSIONS_USED = QLatin1String("extensionsUsed");
+const QLatin1String KEY_EXTENSIONS_REQUIRED = QLatin1String("extensionsRequired");
+const QLatin1String KEY_ANIMATIONS = QLatin1String("animations");
+const QLatin1String KEY_MATERIALS = QLatin1String("materials");
+const QLatin1String KEY_SKINS = QLatin1String("skins");
+const QLatin1String KEY_BYTELENGTH = QLatin1String("byteLength");
+const QLatin1String KEY_URI = QLatin1String("uri");
+const QLatin1String KEY_PRIMITIVES = QLatin1String("primitives");
+const QLatin1String KEY_NAME = QLatin1String("name");
+const QLatin1String KEY_BUFFER = QLatin1String("buffer");
+const QLatin1String KEY_BUFFERVIEW = QLatin1String("bufferView");
+const QLatin1String KEY_ATTRIBUTES = QLatin1String("attributes");
+const QLatin1String KEY_BYTEOFFSET = QLatin1String("byteOffset");
+const QLatin1String KEY_BYTESTRIDE = QLatin1String("byteStride");
+const QLatin1String KEY_INDICES = QLatin1String("indices");
+const QLatin1String KEY_VALUES = QLatin1String("values");
+const QLatin1String KEY_SPARSE = QLatin1String("sparse");
+#if defined(KUESA_DRACO_COMPRESSION)
+const QLatin1String KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION = QLatin1String("KHR_draco_mesh_compression");
+#endif
+
+} // namespace GLTF2Import
+} // namespace Kuesa
+
+QT_END_NAMESPACE
+
+#endif // KUESA_GLTF2IMPORT_GLTF2KEYS_P_H

--- a/src/core/gltf2importer/gltf2parser.cpp
+++ b/src/core/gltf2importer/gltf2parser.cpp
@@ -27,6 +27,7 @@
 */
 
 #include "gltf2parser_p.h"
+#include "gltf2keys_p.h"
 #include "kuesa_p.h"
 #include "kuesa_utils_p.h"
 #include "bufferparser_p.h"
@@ -71,30 +72,6 @@ using namespace Kuesa;
 using namespace GLTF2Import;
 
 namespace {
-const QLatin1String KEY_BUFFERS = QLatin1Literal("buffers");
-const QLatin1String KEY_BUFFERVIEWS = QLatin1Literal("bufferViews");
-const QLatin1String KEY_ACCESSORS = QLatin1Literal("accessors");
-const QLatin1String KEY_NODES = QLatin1Literal("nodes");
-const QLatin1String KEY_MESHES = QLatin1Literal("meshes");
-const QLatin1String KEY_SCENE = QLatin1Literal("scene");
-const QLatin1String KEY_SCENES = QLatin1Literal("scenes");
-const QLatin1String KEY_KDAB_KUESA_LAYER_EXTENSION = QLatin1String("KDAB_Kuesa_Layers");
-const QLatin1String KEY_MSFT_DDS_EXTENSION = QLatin1String("MSFT_texture_dds");
-const QLatin1String KEY_KUESA_LAYERS = QLatin1Literal("layers");
-const QLatin1String KEY_CAMERAS = QLatin1Literal("cameras");
-const QLatin1String KEY_IMAGES = QLatin1Literal("images");
-const QLatin1String KEY_TEXTURE_SAMPLERS = QLatin1Literal("samplers");
-const QLatin1String KEY_TEXTURES = QLatin1String("textures");
-const QLatin1String KEY_EXTENSIONS = QLatin1String("extensions");
-const QLatin1String KEY_EXTENSIONS_USED = QLatin1String("extensionsUsed");
-const QLatin1String KEY_EXTENSIONS_REQUIRED = QLatin1String("extensionsRequired");
-const QLatin1String KEY_ANIMATIONS = QLatin1String("animations");
-const QLatin1String KEY_MATERIALS = QLatin1String("materials");
-const QLatin1String KEY_SKINS = QLatin1String("skins");
-#if defined(KUESA_DRACO_COMPRESSION)
-const QLatin1String KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION = QLatin1String("KHR_draco_mesh_compression");
-#endif
-
 template<class CollectionType>
 void addToCollectionWithUniqueName(CollectionType *collection, const QString &basename, typename CollectionType::ContentType *asset)
 {
@@ -313,6 +290,8 @@ Qt3DCore::QEntity *GLTF2Parser::parse(const QByteArray &jsonData, const QString 
     }
 
     Q_ASSERT(m_context);
+    m_context->setJson(jsonDocument);
+
     m_animators.clear();
     m_treeNodes.clear();
     m_skeletons.clear();

--- a/src/core/gltf2importer/meshparser.cpp
+++ b/src/core/gltf2importer/meshparser.cpp
@@ -26,6 +26,10 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#if defined(KUESA_DRACO_COMPRESSION)
+#include <draco/compression/decode.h>
+#endif
+
 #include "meshparser_p.h"
 #include "bufferviewsparser_p.h"
 #include "gltf2context_p.h"
@@ -41,10 +45,6 @@
 #include <Qt3DRender/QGeometryRenderer>
 
 #include <QtGui/qopengl.h>
-
-#if defined(KUESA_DRACO_COMPRESSION)
-#include <draco/compression/decode.h>
-#endif
 
 QT_BEGIN_NAMESPACE
 using namespace Kuesa;
@@ -284,6 +284,7 @@ bool MeshParser::geometryAttributesFromJSON(Qt3DRender::QGeometry *geometry,
         attribute->setProperty("bufferViewIndex", accessor.bufferViewIndex);
         attribute->setProperty("bufferViewOffset", viewData.byteOffset);
         attribute->setProperty("bufferName", accessor.name);
+        attribute->setProperty("semanticName", attrName);
         geometry->addAttribute(attribute);
     }
 
@@ -451,6 +452,7 @@ bool MeshParser::geometryAttributesDracoFromJSON(Qt3DRender::QGeometry *geometry
         attribute->setProperty("bufferViewIndex", accessor.bufferViewIndex);
         attribute->setProperty("bufferViewOffset", accessor.offset);
         attribute->setProperty("bufferName", accessor.name);
+        attribute->setProperty("semanticName", attrName);
 
         geometry->addAttribute(attribute);
     }

--- a/src/core/metallicroughnessmaterial.cpp
+++ b/src/core/metallicroughnessmaterial.cpp
@@ -48,11 +48,18 @@ template<class OutputType>
 using ValueTypeMapper = typename std::remove_const<typename std::remove_reference<OutputType>::type>::type;
 
 template<class OutputType>
-auto wrapParameterSignal(MetallicRoughnessMaterial *self, SignalType<OutputType> sig)
+struct WrappedSignal
 {
-    return [self, sig](const QVariant &value) {
+    MetallicRoughnessMaterial *self;
+    SignalType<OutputType> sig;
+    void operator()(const QVariant &value) const {
         std::mem_fn(sig)(self, value.value<ValueTypeMapper<OutputType>>());
-    };
+    }
+};
+template<class OutputType>
+WrappedSignal<OutputType> wrapParameterSignal(MetallicRoughnessMaterial *self, SignalType<OutputType> sig)
+{
+    return WrappedSignal<OutputType>{self, sig};
 }
 
 /*!

--- a/tests/auto/assets/car
+++ b/tests/auto/assets/car
@@ -1,0 +1,1 @@
+../../../examples/kuesa/assets/models/car

--- a/tests/auto/gltfexporter/gltfexporter.pro
+++ b/tests/auto/gltfexporter/gltfexporter.pro
@@ -1,9 +1,9 @@
-# auto.pro
+# gltfexporter.pro
 #
 # This file is part of Kuesa.
 #
-# Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-# Author: Mike Krus <mike.krus@kdab.com>
+# Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 #
 # Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
 # accordance with the Kuesa Enterprise License Agreement provided with the Software in the
@@ -24,41 +24,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-TEMPLATE = subdirs
+TEMPLATE = app
 
-SUBDIRS = \
-#    cmake \
-    assetcollection \
-    meshcollection \
-    texturecollection \
-    skeletoncollection \
-    animationclipcollection \
-    effectcollection \
-    sceneentity \
-    textureimagecollection \
-    assetpipelineeditor
+TARGET = tst_gltfexporter
 
-#installed_cmake.depends = cmake
+QT += testlib kuesa kuesa-private
 
-qtConfig(private_tests) {
-    SUBDIRS += \
-        bufferparser \
-        bufferviewparser \
-        bufferaccessorparser \
-        cameraparser \
-        meshparser \
-        nodeparser \
-        gltfparser \
-        gltfexporter \
-        layerparser \
-        imageparser \
-        texturesamplerparser \
-        textureparser \
-        animationparser \
-        sceneparser \
-        materialparser \
-        skinparser \
-        postfxlistextension \
-        assetitem \
-        forwardrenderer
-}
+CONFIG += testcase console
+
+SOURCES += tst_gltfexporter.cpp
+
+qtConfig(kuesa-draco) : DEFINES += KUESA_DRACO_COMPRESSION
+
+include(../assets/assets.pri)

--- a/tests/auto/gltfexporter/tst_gltfexporter.cpp
+++ b/tests/auto/gltfexporter/tst_gltfexporter.cpp
@@ -1,0 +1,236 @@
+/*
+    tst_gltfexporter.cpp
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <QtTest/QtTest>
+#include <Kuesa/SceneEntity>
+#include <Kuesa/GLTF2Importer>
+#include <Kuesa/private/gltf2context_p.h>
+#include <Kuesa/private/gltf2exporter_p.h>
+#include <Kuesa/private/gltf2parser_p.h>
+#include <Kuesa/private/kuesa_utils_p.h>
+using namespace Kuesa;
+using namespace GLTF2Import;
+
+namespace {
+static QDir setupTestFolder()
+{
+    QDir tmp(QStandardPaths::standardLocations(QStandardPaths::TempLocation)[0]);
+    if (tmp.exists("kuesa-gltfexporter-test")) {
+        tmp.cd("kuesa-gltfexporter-test");
+        tmp.removeRecursively();
+        tmp.cdUp();
+    }
+    tmp.mkdir("kuesa-gltfexporter-test");
+    tmp.cd("kuesa-gltfexporter-test");
+    tmp.setFilter(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
+    return tmp;
+}
+} // namespace
+
+class tst_GLTFExporter : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+#if defined(KUESA_DRACO_COMPRESSION)
+    void checkBoxCompression()
+    {
+        SceneEntity scene;
+        GLTF2Context ctx;
+
+        GLTF2Parser parser(&scene);
+        parser.setContext(&ctx);
+
+        QString asset(ASSETS "Box.gltf");
+        QDir tmp = setupTestFolder();
+
+        QJsonObject new_asset;
+        // WHEN
+        {
+            auto res = parser.parse(asset);
+            QVERIFY(res != nullptr);
+
+            GLTF2ExportConfiguration configuration;
+            configuration.setMeshCompressionEnabled(true);
+            configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Position, 5);
+            configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Normal, 5);
+
+            GLTF2Exporter exporter;
+            exporter.setContext(&ctx);
+            exporter.setScene(&scene);
+            exporter.setConfiguration(configuration);
+
+            QFile asset_file(asset);
+            asset_file.open(QIODevice::ReadOnly);
+            new_asset = exporter.saveInFolder(
+                    QDir(ASSETS),
+                    tmp);
+        }
+
+        // THEN
+        {
+            QVERIFY(!new_asset.empty());
+
+            ctx = GLTF2Context{};
+            auto res = parser.parse(QJsonDocument{ new_asset }.toJson(), tmp.absolutePath());
+            QVERIFY(res != nullptr);
+
+            QVERIFY(tmp.exists("compressedBuffer.bin"));
+            QVERIFY(!tmp.exists("Box0.bin"));
+            QCOMPARE(tmp.count(), 1U);
+        }
+    }
+
+    void checkCarCompression()
+    {
+        SceneEntity scene;
+        GLTF2Context ctx;
+
+        GLTF2Parser parser(&scene);
+        parser.setContext(&ctx);
+
+        QDir source_dir(ASSETS "car/");
+        QString asset(ASSETS "car/DodgeViper.gltf");
+        QDir tmp = setupTestFolder();
+
+        QJsonObject new_asset;
+        // WHEN
+        {
+            auto res = parser.parse(asset);
+            QVERIFY(res != nullptr);
+
+            GLTF2ExportConfiguration configuration;
+            configuration.setMeshCompressionEnabled(true);
+            configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Position, 4);
+            configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Normal, 4);
+            configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Color, 4);
+            configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::TextureCoordinate, 4);
+            configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Generic, 4);
+
+            GLTF2Exporter exporter;
+            exporter.setContext(&ctx);
+            exporter.setScene(&scene);
+            exporter.setConfiguration(configuration);
+
+            QFile asset_file(asset);
+            asset_file.open(QIODevice::ReadOnly);
+            new_asset = exporter.saveInFolder(
+                    source_dir,
+                    tmp);
+
+            // Original model is 14 megabytes
+            QFileInfo dodge_info(source_dir.filePath("DodgeViper.bin"));
+            QVERIFY(dodge_info.size() == 14406004);
+        }
+
+        // THEN
+        {
+            QVERIFY(!new_asset.empty());
+
+            // Check that a compressed buffer is created
+            QVERIFY(tmp.exists("compressedBuffer.bin"));
+
+            // Check that all the remaining data is correctly copied
+            QVERIFY(tmp.exists("DodgeViper.bin"));
+            QVERIFY(tmp.exists("hex-base.png.png"));
+            QVERIFY(tmp.exists("hex-normal.png.png"));
+            QVERIFY(tmp.exists("KDABnormal.png.png"));
+            QVERIFY(tmp.exists("KDAB.png.png"));
+            QVERIFY(tmp.exists("shadow-plane.png.png"));
+            QCOMPARE(tmp.count(), 7U);
+
+            // Some non-mesh data remains
+            QFileInfo dodge_info(tmp.filePath("DodgeViper.bin"));
+            QVERIFY(dodge_info.size() == 21898);
+
+            // Compressed mesh is less than a megabyte
+            QFileInfo comp_info(tmp.filePath("compressedBuffer.bin"));
+            QVERIFY(comp_info.size() < 1024 * 1024);
+
+            // Check that we can reload the mesh properly
+            ctx = GLTF2Context{};
+            auto res = parser.parse(QJsonDocument{ new_asset }.toJson(), tmp.absolutePath());
+            QVERIFY(res != nullptr);
+        }
+    }
+
+    void noChangesIfAlreadyCompressd()
+    {
+        SceneEntity scene;
+        GLTF2Context ctx;
+
+        GLTF2Parser parser(&scene);
+        parser.setContext(&ctx);
+
+        QString asset(ASSETS "draco/Box.gltf");
+        QFile asset_file(asset);
+        asset_file.open(QIODevice::ReadOnly);
+        QJsonObject asset_json{ QJsonDocument::fromJson({ asset_file.readAll() }).object() };
+        asset_file.close();
+
+        QDir tmp = setupTestFolder();
+
+        QJsonObject new_asset;
+        // WHEN
+        {
+            auto res = parser.parse(asset);
+            QVERIFY(res != nullptr);
+
+            GLTF2ExportConfiguration configuration;
+            configuration.setMeshCompressionEnabled(true);
+            configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Position, 5);
+            configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Normal, 5);
+
+            GLTF2Exporter exporter;
+            exporter.setContext(&ctx);
+            exporter.setScene(&scene);
+            exporter.setConfiguration(configuration);
+
+            QFile asset_file(asset);
+            asset_file.open(QIODevice::ReadOnly);
+            new_asset = exporter.saveInFolder(
+                    QDir(ASSETS "draco"),
+                    tmp);
+        }
+
+        // THEN
+        {
+            // JSON hasn't changed
+            QVERIFY(asset_json == new_asset);
+
+            // Referenced buffer Box0.bin is copied
+            QCOMPARE(tmp.count(), 1);
+        }
+    }
+#endif
+};
+
+QTEST_APPLESS_MAIN(tst_GLTFExporter)
+
+#include "tst_gltfexporter.moc"

--- a/tools/assetpipelineeditor/assetpipelineeditor.pro
+++ b/tools/assetpipelineeditor/assetpipelineeditor.pro
@@ -47,7 +47,8 @@ SOURCES += \
     textureinspector.cpp \
     texturepreviewmaterial.cpp \
     settingsdialog.cpp \
-    orbitcameracontroller.cpp
+    orbitcameracontroller.cpp \
+    exportdialog.cpp
 
 HEADERS += \
     mainwindow.h \
@@ -66,7 +67,8 @@ HEADERS += \
     textureinspector.h \
     texturepreviewmaterial.h \
     settingsdialog.h \
-    orbitcameracontroller.h
+    orbitcameracontroller.h \
+    exportdialog.h
 
 FORMS += \
     animationwidget.ui \
@@ -76,7 +78,8 @@ FORMS += \
     materialwidget.ui \
     meshwidget.ui \
     texturewidget.ui \
-    settingsdialog.ui
+    settingsdialog.ui \
+    exportdialog.ui
 
 RESOURCES += \
     qml.qrc \
@@ -100,6 +103,8 @@ macos {
 windows {
     RC_ICONS = ../../resources/kuesa.ico
 }
+
+qtConfig(kuesa-draco) : DEFINES += KUESA_DRACO_COMPRESSION
 
 target.path = $$[QT_INSTALL_BINS]
 INSTALLS += target

--- a/tools/assetpipelineeditor/exportdialog.cpp
+++ b/tools/assetpipelineeditor/exportdialog.cpp
@@ -1,0 +1,151 @@
+/*
+    exportdialog.cpp
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "exportdialog.h"
+#include "ui_exportdialog.h"
+
+#include <Kuesa/private/gltf2exporter_p.h>
+
+#include <QtWidgets/QAction>
+#include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QJsonDocument>
+#include <QFileDialog>
+#include <QStyle>
+#include <QPushButton>
+#include <QMessageBox>
+#include <QStyle>
+
+ExportDialog::ExportDialog(Kuesa::GLTF2Exporter &exporter, const QString &path, QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::ExportDialog)
+    , m_exporter(exporter)
+    , m_originalFile(path)
+    , m_targetFile(m_originalFile)
+{
+    ui->setupUi(this);
+
+    ui->sourceLabel->setText(tr("Saving: ") + m_originalFile);
+
+    auto act = ui->destination->addAction(
+                style()->standardIcon(QStyle::StandardPixmap::SP_DialogOpenButton),
+                QLineEdit::ActionPosition::TrailingPosition);
+    connect(act, &QAction::triggered, this, [=] {
+        auto res = QFileDialog::getSaveFileName(
+                    this,
+                    tr("Save glTF file"),
+                    m_targetFile,
+                    tr("glTF 2.0 file (*.gltf)"));
+        ui->destination->setText(res);
+    });
+
+    auto save_btn = ui->buttonBox->button(QDialogButtonBox::Save);
+    connect(save_btn, &QPushButton::clicked,
+            this, &ExportDialog::onSave);
+
+    connect(ui->destination, &QLineEdit::textChanged,
+            this, [=] (const QString& text){
+        m_targetFile = text;
+        save_btn->setEnabled(!m_targetFile.isEmpty());
+    });
+    save_btn->setDisabled(true);
+}
+
+ExportDialog::~ExportDialog()
+{
+    delete ui;
+}
+
+void ExportDialog::onSave()
+{
+    ui->errorLog->setPlainText("");
+
+    const QDir orig_dir = QFileInfo(m_originalFile).dir();
+    const QDir target_dir = QFileInfo(m_targetFile).dir();
+    if (orig_dir.absolutePath() == target_dir.absolutePath()) {
+        const int res = QMessageBox::warning(
+                this, tr("Destructive operation"),
+                tr("Saving in the original folder will overwrite assets."),
+                QMessageBox::Ok | QMessageBox::Cancel,
+                QMessageBox::Cancel);
+        if (res != QMessageBox::Ok) {
+            ui->errorLog->setPlainText(tr("Nothing saved."));
+            return;
+        }
+    }
+
+    // Set-up configuration
+    {
+        using ExportConf = Kuesa::GLTF2ExportConfiguration;
+        ExportConf conf;
+
+        conf.setMeshCompressionEnabled(ui->meshCompression->isChecked());
+
+        conf.setMeshEncodingSpeed(ui->encodeSpeedSlider->value());
+        conf.setMeshDecodingSpeed(ui->decodeSpeedSlider->value());
+
+        // The UI sliders are between 0 - 16.
+        // 0 is an invalid compression value for draco,
+        // so we shift everything by one and put 0 to the max position
+        auto mapSlider = [](QSlider *s) {
+            const auto max = s->maximum();
+            const auto v = s->value();
+            if (v == max)
+                return 0;
+            else
+                return v + 1;
+        };
+        conf.setAttributeQuantizationLevel(ExportConf::Position, mapSlider(ui->positionQuantizationSlider));
+        conf.setAttributeQuantizationLevel(ExportConf::Normal, mapSlider(ui->normalQuantizationSlider));
+        conf.setAttributeQuantizationLevel(ExportConf::Color, mapSlider(ui->colorQuantizationSlider));
+        conf.setAttributeQuantizationLevel(ExportConf::TextureCoordinate, mapSlider(ui->textureQuantizationSlider));
+        conf.setAttributeQuantizationLevel(ExportConf::Generic, mapSlider(ui->genericQuantizationSlider));
+
+        m_exporter.setConfiguration(conf);
+    }
+
+    const auto rootObject = m_exporter.saveInFolder(orig_dir, target_dir);
+
+    for (const auto &error : m_exporter.errors()) {
+        ui->errorLog->appendPlainText(error);
+        ui->errorLog->appendPlainText(QStringLiteral("\n"));
+    }
+    if (rootObject.empty()) {
+        return;
+    }
+
+    QFile outFile(m_targetFile);
+    if (outFile.open(QIODevice::WriteOnly)) {
+        outFile.write(QJsonDocument(rootObject).toJson());
+
+        ui->errorLog->appendPlainText(tr("Successful export."));
+    } else {
+        ui->errorLog->appendPlainText(tr("Cannot write to output file."));
+    }
+}

--- a/tools/assetpipelineeditor/exportdialog.h
+++ b/tools/assetpipelineeditor/exportdialog.h
@@ -1,0 +1,61 @@
+/*
+    exportdialog.h
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef EXPORTDIALOG_H
+#define EXPORTDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class ExportDialog;
+}
+
+namespace Kuesa {
+class GLTF2Exporter;
+}
+class ExportDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ExportDialog(Kuesa::GLTF2Exporter &exporter,
+                          const QString &originalPath,
+                          QWidget *parent = nullptr);
+    ~ExportDialog();
+
+private:
+    void onSave();
+    void setTargetFile(const QString &p);
+    Ui::ExportDialog *ui;
+    Kuesa::GLTF2Exporter &m_exporter;
+    QString m_originalFile;
+    QString m_targetFile;
+    QString m_warningText;
+};
+
+#endif // EXPORTDIALOG_H

--- a/tools/assetpipelineeditor/exportdialog.ui
+++ b/tools/assetpipelineeditor/exportdialog.ui
@@ -1,0 +1,434 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExportDialog</class>
+ <widget class="QDialog" name="ExportDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>661</width>
+    <height>553</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Export</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Destination:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="destination"/>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="sourceLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Source: </string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QPlainTextEdit" name="errorLog">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2" rowspan="4">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Save|QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QGroupBox" name="meshCompression">
+     <property name="title">
+      <string>&amp;Mesh compression</string>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0,0,0">
+      <item row="7" column="0">
+       <widget class="QLabel" name="decodeSpeedLabel">
+        <property name="toolTip">
+         <string>Higher means faster decompression at the cost of a less compressed asset.</string>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Decoding speed</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="genericQuantizationLabel">
+        <property name="toolTip">
+         <string>Quantization of every other data present in the asset (joints, etc.)</string>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Generic data quality</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSlider" name="genericQuantizationSlider">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Quantization of every other data present in the asset (joints, etc.)</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>16</number>
+        </property>
+        <property name="value">
+         <number>8</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="invertedAppearance">
+         <bool>false</bool>
+        </property>
+        <property name="invertedControls">
+         <bool>false</bool>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSlider" name="positionQuantizationSlider">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Quantization of the vertex position information.</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>16</number>
+        </property>
+        <property name="value">
+         <number>8</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="invertedAppearance">
+         <bool>false</bool>
+        </property>
+        <property name="invertedControls">
+         <bool>false</bool>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="encodeSpeedLabel">
+        <property name="toolTip">
+         <string>Higher means faster but less effective compression.</string>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Encoding speed</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="colorQuantizationLabel">
+        <property name="whatsThis">
+         <string>Quantization of the color data.</string>
+        </property>
+        <property name="text">
+         <string>Color quality</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QSlider" name="encodeSpeedSlider">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Higher means faster but less effective compression.</string>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>5</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="textureQuantizationLabel">
+        <property name="toolTip">
+         <string>Quantization of the texture coordinates information.</string>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>TexCoord quality</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QSlider" name="textureQuantizationSlider">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Quantization of the texture coordinates information.</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>16</number>
+        </property>
+        <property name="value">
+         <number>8</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="invertedAppearance">
+         <bool>false</bool>
+        </property>
+        <property name="invertedControls">
+         <bool>false</bool>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSlider" name="colorQuantizationSlider">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>16</number>
+        </property>
+        <property name="value">
+         <number>8</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="invertedAppearance">
+         <bool>false</bool>
+        </property>
+        <property name="invertedControls">
+         <bool>false</bool>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="positionQuantizationLabel">
+        <property name="toolTip">
+         <string>Quantization of the vertex position information.</string>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Position quality</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSlider" name="normalQuantizationSlider">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Quantization of the vertex normals information.</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>16</number>
+        </property>
+        <property name="value">
+         <number>8</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="invertedAppearance">
+         <bool>false</bool>
+        </property>
+        <property name="invertedControls">
+         <bool>false</bool>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="normalQuantizationLabel">
+        <property name="toolTip">
+         <string>Quantization of the vertex normals information.</string>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Normal quality</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QSlider" name="decodeSpeedSlider">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Higher means faster decompression at the cost of a less compressed asset.</string>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>5</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBelow</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="emptyRow">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ExportDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>651</x>
+     <y>269</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/tools/assetpipelineeditor/mainwindow.h
+++ b/tools/assetpipelineeditor/mainwindow.h
@@ -85,6 +85,7 @@ protected:
 
 private slots:
     void openFile();
+    void exportFile();
     void reloadFile();
     void about();
     void setCamera(int index);

--- a/tools/assetpipelineeditor/mainwindow.ui
+++ b/tools/assetpipelineeditor/mainwindow.ui
@@ -29,9 +29,10 @@
    </property>
    <widget class="QMenu" name="menuFile">
     <property name="title">
-     <string>File</string>
+     <string>&amp;File</string>
     </property>
     <addaction name="actionOpen"/>
+    <addaction name="actionExport"/>
     <addaction name="actionReload"/>
     <addaction name="separator"/>
     <addaction name="actionQuit"/>
@@ -44,7 +45,7 @@
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>View</string>
+     <string>&amp;View</string>
     </property>
    </widget>
    <widget class="QMenu" name="menuEdit">
@@ -61,7 +62,7 @@
   </widget>
   <widget class="QDockWidget" name="collectionBrowserDockWidget">
    <property name="windowTitle">
-    <string>Collection Browser</string>
+    <string>Collection &amp;Browser</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>1</number>
@@ -101,13 +102,15 @@
     <bool>false</bool>
    </attribute>
    <addaction name="actionOpen"/>
+   <addaction name="actionExport"/>
    <addaction name="actionReload"/>
    <addaction name="separator"/>
    <addaction name="actionViewAll"/>
+   <addaction name="separator"/>
   </widget>
   <widget class="QDockWidget" name="assetInspectorDockWidget">
    <property name="windowTitle">
-    <string>Asset Inspector</string>
+    <string>Asset &amp;Inspector</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>1</number>
@@ -131,7 +134,7 @@
   </widget>
   <widget class="QDockWidget" name="animationDockWidget">
    <property name="windowTitle">
-    <string>Animations</string>
+    <string>&amp;Animations</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -140,7 +143,7 @@
   </widget>
   <widget class="QDockWidget" name="cameraDockWidget">
    <property name="windowTitle">
-    <string>Camera Settings</string>
+    <string>&amp;Camera Settings</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -159,7 +162,7 @@
   </action>
   <action name="actionQuit">
    <property name="text">
-    <string>Quit</string>
+    <string>&amp;Quit</string>
    </property>
   </action>
   <action name="actionReload">
@@ -167,7 +170,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Reload</string>
+    <string>&amp;Reload</string>
    </property>
   </action>
   <action name="actionViewAll">
@@ -183,7 +186,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Copy</string>
+    <string>&amp;Copy</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+C</string>
@@ -191,10 +194,24 @@
   </action>
   <action name="actionSettings">
    <property name="text">
-    <string>Settings</string>
+    <string>&amp;Settings</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+,</string>
+   </property>
+  </action>
+  <action name="actionExport">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Export...</string>
+   </property>
+   <property name="iconText">
+    <string>Export...</string>
+   </property>
+   <property name="toolTip">
+    <string>Export</string>
    </property>
   </action>
  </widget>

--- a/tools/assetpipelineeditor/meshinspector.cpp
+++ b/tools/assetpipelineeditor/meshinspector.cpp
@@ -32,7 +32,7 @@
 #include <Qt3DRender/QAttribute>
 #include <Qt3DCore/QEntity>
 #include <Kuesa/MetallicRoughnessMaterial>
-#include <private/kuesa_utils_p.h>
+#include <Kuesa/private/kuesa_utils_p.h>
 
 MeshInspector::MeshInspector(QObject *parent)
     : QObject(parent)


### PR DESCRIPTION
This pull request starts to have something that looks like a working implementation (see https://github.com/KDAB/kuesa/pull/16/files?w=1 to get a diff without the whitespace changes - github really ought to have a nice button for this).

### What works
* Compressing and reloading these in Kuesa: 
  - https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Box/glTF
  - https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Cube/glTF
  - https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/AnimatedCube/glTF
  - https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BoxAnimated/glTF
  - https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Duck/glTF
  - https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Buggy/glTF
  - The DodgeViper example

### What doesn't
* Original buffers aren't stripped of uncompressed data properly yet (it works if there is no interleaving of multiple bufferViews) - edit : actually it looks like this works (at least the interleaved glTF example works : https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BoxInterleaved ) ; I suppose that this is because once we're in the Qt3D world (as the mesh data are), there is no interleaving anymore ? 

* Currently, all the indices relative to the following bufferViews in the whole GLTF file (in known extensions) are readjusted. But if someone has a custom extension that also uses bufferViews to access data, we won't have any way to know that we have to adjust them and this will break the custom extension. (and we can't assume that it will be exposed as `"bufferView": 123` to try and replace them, it may be a different key like the ones used in `"primitives"`).

### What's missing
* tests, prettyfication, proper comments and documentation
* support for embedded data (depends on https://github.com/KDAB/kuesa/pull/25)
