### PR TITLE
Use the node factory rather than operator new

### DIFF
--- a/src/core/gltf2importer/gltf2parser.cpp
+++ b/src/core/gltf2importer/gltf2parser.cpp
@@ -51,6 +51,7 @@
 
 #include <functional>
 
+#include <Qt3DCore/private/qabstractnodefactory_p.h>
 #include <Qt3DCore/QEntity>
 #include <Qt3DCore/QJoint>
 #include <Qt3DCore/QTransform>
@@ -558,7 +559,7 @@ void GLTF2Parser::buildEntitiesAndJointsGraph()
                 if (node.cameraIdx >= 0)
                     node.entity = new Qt3DRender::QCamera();
                 else
-                    node.entity = new Qt3DCore::QEntity();
+                    node.entity = Qt3DCore::QAbstractNodeFactory::createNode<Qt3DCore::QEntity>("QEntity");
             }
             // Set ourselves as parent of our last child
             if (lastChild != nullptr)
@@ -614,7 +615,7 @@ void GLTF2Parser::generateTreeNodeContent()
 {
     Qt3DCore::QComponent *defaultMaterial = nullptr;
     Qt3DCore::QComponent *defaultSkinnedMaterial = nullptr;
-    m_sceneRootEntity = new Qt3DCore::QEntity();
+    m_sceneRootEntity = Qt3DCore::QAbstractNodeFactory::createNode<Qt3DCore::QEntity>("QEntity");
     m_sceneRootEntity->setObjectName(QStringLiteral("GLTF2Scene"));
 
     for (TreeNode &node : m_treeNodes) {
@@ -742,7 +743,7 @@ void GLTF2Parser::generateTreeNodeContent()
 
                 // Generate one Entity per primitive (1 primitive == 1 geometry renderer)
                 for (Primitive primitiveData : meshData.meshPrimitives) {
-                    Qt3DCore::QEntity *primitiveEntity = new Qt3DCore::QEntity();
+                    Qt3DCore::QEntity *primitiveEntity = Qt3DCore::QAbstractNodeFactory::createNode<Qt3DCore::QEntity>("QEntity");
                     primitiveEntity->addComponent(primitiveData.primitiveRenderer);
 
                     // Add material for mesh


### PR DESCRIPTION
The issue is that when the glTF parser creates QNode subclass
instances using operator new, we always only get the plain old
C++ objects. This is an issue when using QML to drive the
application and when you want to access properties on types that
have been registered with QML as extended types.

The QAbstractNodeFactory will automatically have inner factories
registered at application start up by the QML plugins. That means
we should use the factory to create the nodes rather than operator
new.

This commit does it only for Qt3DCore::QEntity to prove that it
works.

Without this commit accessing a Kuesa.Asset.node in QML code only
gives access to the basic QNode properties. With this commit we
get access to the properties defined on the QEntity extension
object too - namely the list of components. We can then use this
to mutate the entity by adding more components such as an
object picker to integrate the scene with our application logic.