### PR TITLE
Export: change API in order to get the output filename

### DIFF
--- a/src/core/gltf2exporter/gltf2exporter_p.h
+++ b/src/core/gltf2exporter/gltf2exporter_p.h
@@ -90,6 +90,19 @@ class KUESA_PRIVATE_EXPORT GLTF2Exporter : public QObject
     Q_PROPERTY(SceneEntity *scene READ scene WRITE setScene NOTIFY sceneChanged)
 
 public:
+    class Export
+    {
+    public:
+        bool success() const;
+        const QJsonObject &json() const;
+        const QString &compressedBufferFilename() const;
+
+    private:
+        friend class GLTF2Exporter;
+        QJsonObject m_json;
+        QString m_compressedBufferFilename;
+    };
+
     explicit GLTF2Exporter(QObject *parent = nullptr);
 
     SceneEntity *scene() const;
@@ -107,7 +120,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void setScene(SceneEntity *scene);
 
-    QJsonObject saveInFolder(
+    Export saveInFolder(
             const QDir &sourceFolder,
             const QDir &targetFolder);
 

--- a/tools/assetpipelineeditor/exportdialog.cpp
+++ b/tools/assetpipelineeditor/exportdialog.cpp
@@ -130,19 +130,19 @@ void ExportDialog::onSave()
         m_exporter.setConfiguration(conf);
     }
 
-    const auto rootObject = m_exporter.saveInFolder(orig_dir, target_dir);
+    const auto exported = m_exporter.saveInFolder(orig_dir, target_dir);
 
     for (const auto &error : m_exporter.errors()) {
         ui->errorLog->appendPlainText(error);
         ui->errorLog->appendPlainText(QStringLiteral("\n"));
     }
-    if (rootObject.empty()) {
+    if (!exported.success()) {
         return;
     }
 
     QFile outFile(m_targetFile);
     if (outFile.open(QIODevice::WriteOnly)) {
-        outFile.write(QJsonDocument(rootObject).toJson());
+        outFile.write(QJsonDocument(exported.json()).toJson());
 
         ui->errorLog->appendPlainText(tr("Successful export."));
     } else {


### PR DESCRIPTION
Before it was not possible to know in which file the compressed buffer was written.
This will be useful to perform statistics for instance (e.g. for #38 or later if we also do it in the UI).