### PR TITLE
Warn the user about the assets that may be overwritten while exporting.

### DIFF
--- a/src/core/gltf2exporter/gltf2exporter_p.cpp
+++ b/src/core/gltf2exporter/gltf2exporter_p.cpp
@@ -664,6 +664,19 @@ void GLTF2Exporter::setContextFromImporter(GLTF2Importer *importer)
     m_context = importer->m_context;
 }
 
+QStringList GLTF2Exporter::overwritableFiles(const QDir &target) const
+{
+    QStringList files;
+    for (const auto& file : m_context->localFiles()) {
+        auto filePath = GLTF2Import::Uri::localFile(file, target);
+        if (!filePath.startsWith(QStringLiteral(":/"))) {
+            if (QFileInfo::exists(filePath))
+                files.append(filePath);
+        }
+    }
+    return files;
+}
+
 auto GLTF2Exporter::saveInFolder(
         const QDir &source,
         const QDir &target) -> Export

--- a/src/core/gltf2exporter/gltf2exporter_p.h
+++ b/src/core/gltf2exporter/gltf2exporter_p.h
@@ -114,6 +114,8 @@ public:
     void setContext(GLTF2Import::GLTF2Context *context);
     void setContextFromImporter(GLTF2Importer *importer);
 
+    QStringList overwritableFiles(const QDir &target) const;
+
 Q_SIGNALS:
     void sceneChanged(SceneEntity *scene);
 

--- a/src/core/gltf2importer/bufferparser.cpp
+++ b/src/core/gltf2importer/bufferparser.cpp
@@ -86,6 +86,9 @@ bool BufferParser::parse(const QJsonArray &buffersArray, GLTF2Context *context) 
         if (!uri.isNull()) {
             const QByteArray data = Uri::fetchData(uri, m_basePath, readSuccess);
             if (readSuccess) {
+                if (Uri::kind(uri) == Uri::Kind::Path)
+                    context->addLocalFile(uri);
+
                 const bool hasExpectedSize = data.size() == expectedSize;
                 if (hasExpectedSize) {
                     context->addBuffer(data);

--- a/src/core/gltf2importer/gltf2context.cpp
+++ b/src/core/gltf2importer/gltf2context.cpp
@@ -350,6 +350,16 @@ void GLTF2Context::setJson(const QJsonDocument &doc)
     m_json = doc;
 }
 
+const QStringList &GLTF2Context::localFiles() const
+{
+    return m_localFiles;
+}
+
+void GLTF2Context::addLocalFile(const QString &file)
+{
+    m_localFiles.push_back(file);
+}
+
 template<>
 int GLTF2Context::count<Mesh>() const
 {

--- a/src/core/gltf2importer/gltf2context_p.h
+++ b/src/core/gltf2importer/gltf2context_p.h
@@ -146,6 +146,9 @@ public:
     const QJsonDocument &json() const;
     void setJson(const QJsonDocument &doc);
 
+    const QStringList &localFiles() const;
+    void addLocalFile(const QString &file);
+
 private:
     QVector<Accessor> m_accessors;
     QVector<QByteArray> m_buffers;
@@ -164,6 +167,7 @@ private:
     QStringList m_usedExtensions;
     QStringList m_requiredExtensions;
     QJsonDocument m_json;
+    QStringList m_localFiles;
 };
 
 template<>

--- a/src/core/gltf2importer/imageparser.cpp
+++ b/src/core/gltf2importer/imageparser.cpp
@@ -77,6 +77,7 @@ bool ImageParser::parse(const QJsonArray &imageArray, GLTF2Context *context) con
                 break;
             }
             case Uri::Kind::Path: {
+                context->addLocalFile(uriString);
                 image.url = Uri::absoluteUrl(uriString, m_basePath);
                 break;
             }

--- a/tools/assetpipelineeditor/exportdialog.cpp
+++ b/tools/assetpipelineeditor/exportdialog.cpp
@@ -54,14 +54,14 @@ ExportDialog::ExportDialog(Kuesa::GLTF2Exporter &exporter, const QString &path, 
     ui->sourceLabel->setText(tr("Saving: ") + m_originalFile);
 
     auto act = ui->destination->addAction(
-                style()->standardIcon(QStyle::StandardPixmap::SP_DialogOpenButton),
-                QLineEdit::ActionPosition::TrailingPosition);
+            style()->standardIcon(QStyle::StandardPixmap::SP_DialogOpenButton),
+            QLineEdit::ActionPosition::TrailingPosition);
     connect(act, &QAction::triggered, this, [=] {
         auto res = QFileDialog::getSaveFileName(
-                    this,
-                    tr("Save glTF file"),
-                    m_targetFile,
-                    tr("glTF 2.0 file (*.gltf)"));
+                this,
+                tr("Save glTF file"),
+                m_targetFile,
+                tr("glTF 2.0 file (*.gltf)"));
         ui->destination->setText(res);
     });
 
@@ -70,10 +70,10 @@ ExportDialog::ExportDialog(Kuesa::GLTF2Exporter &exporter, const QString &path, 
             this, &ExportDialog::onSave);
 
     connect(ui->destination, &QLineEdit::textChanged,
-            this, [=] (const QString& text){
-        m_targetFile = text;
-        save_btn->setEnabled(!m_targetFile.isEmpty());
-    });
+            this, [=](const QString &text) {
+                m_targetFile = text;
+                save_btn->setEnabled(!m_targetFile.isEmpty());
+            });
     save_btn->setDisabled(true);
 }
 
@@ -88,10 +88,13 @@ void ExportDialog::onSave()
 
     const QDir orig_dir = QFileInfo(m_originalFile).dir();
     const QDir target_dir = QFileInfo(m_targetFile).dir();
-    if (orig_dir.absolutePath() == target_dir.absolutePath()) {
+
+    const auto overwritable = m_exporter.overwritableFiles(target_dir);
+
+    if (!overwritable.isEmpty()) {
         const int res = QMessageBox::warning(
                 this, tr("Destructive operation"),
-                tr("Saving in the original folder will overwrite assets."),
+                tr("Saving in the original folder will overwrite the following assets: \n%1").arg(overwritable.join("\n")),
                 QMessageBox::Ok | QMessageBox::Cancel,
                 QMessageBox::Cancel);
         if (res != QMessageBox::Ok) {


### PR DESCRIPTION
This saves a list of the files referenced by a .gltf in the gltf context so that we can check them quickly before exporting.