### PR TITLE
Fix unit tests:

### DIFF
--- a/src/core/gltf2importer/meshparser.cpp
+++ b/src/core/gltf2importer/meshparser.cpp
@@ -78,7 +78,9 @@ QString standardAttributeNameFromSemantic(const QString &semantic)
     if (semantic.startsWith(QLatin1String("TEXCOORD_0")))
         return Qt3DRender::QAttribute::defaultTextureCoordinateAttributeName();
     if (semantic.startsWith(QLatin1String("TEXCOORD_1")))
-        return QString();
+        return Qt3DRender::QAttribute::defaultTextureCoordinate1AttributeName();
+    if (semantic.startsWith(QLatin1String("TEXCOORD_2")))
+        return Qt3DRender::QAttribute::defaultTextureCoordinate2AttributeName();
     if (semantic.startsWith(QLatin1String("COLOR_0")))
         return Qt3DRender::QAttribute::defaultColorAttributeName();
     if (semantic.startsWith(QLatin1String("JOINTS_0")))

--- a/src/core/gltf2importer/meshparser_utils.cpp
+++ b/src/core/gltf2importer/meshparser_utils.cpp
@@ -348,6 +348,29 @@ SMikkTSpaceInterface createMikkTSpaceInterface()
     interface.m_setTSpace = nullptr;
     return interface;
 }
+
+bool vertexBaseTypeForAttributesAreValid(const QVector<Qt3DRender::QAttribute *> &attributes)
+{
+    for (Qt3DRender::QAttribute *attribute : attributes) {
+        const auto validVertexBaseTypes = validVertexBaseTypesForAttribute(attribute->name());
+        const auto vertexBaseType = attribute->vertexBaseType();
+        if (!validVertexBaseTypes.contains(vertexBaseType))
+            return false;
+    }
+    return true;
+}
+
+bool vertexSizesForAttributesAreValid(const QVector<Qt3DRender::QAttribute *> &attributes)
+{
+    for (Qt3DRender::QAttribute *attribute : attributes) {
+        const auto validVertexSizes = validVertexSizesForAttribute(attribute->name());
+        const auto vertexSize = attribute->vertexSize();
+        if (!validVertexSizes.contains(vertexSize))
+            return false;
+    }
+    return true;
+}
+
 } // namespace
 
 // TODO This is only needed when the material has normal mapping
@@ -382,28 +405,8 @@ Qt3DRender::QAttribute *createTangentAttribute(Qt3DRender::QGeometry *geometry, 
 bool geometryIsGLTF2Valid(Qt3DRender::QGeometry *geometry)
 {
     const auto &attributes = geometry->attributes();
-    const bool vertexBaseTypesAreValid = std::find_if(std::begin(attributes), std::end(attributes),
-                                                      [](Qt3DRender::QAttribute *attribute) {
-                                                          const auto validVertexBaseTypes = validVertexBaseTypesForAttribute(attribute->name());
-                                                          const auto vertexBaseType = attribute->vertexBaseType();
-                                                          return std::find_if(std::begin(validVertexBaseTypes),
-                                                                              std::end(validVertexBaseTypes),
-                                                                              [vertexBaseType](Qt3DRender::QAttribute::VertexBaseType validVertexBaseType) {
-                                                                                  return vertexBaseType == validVertexBaseType;
-                                                                              }) == std::end(validVertexBaseTypes);
-                                                      }) == std::end(attributes);
-
-    const bool vertexSizesAreValid = std::find_if(std::begin(attributes), std::end(attributes),
-                                                  [](Qt3DRender::QAttribute *attribute) {
-                                                      const auto validVertexSizes = validVertexSizesForAttribute(attribute->name());
-                                                      const auto vertexSize = attribute->vertexSize();
-                                                      return std::find_if(std::begin(validVertexSizes),
-                                                                          std::end(validVertexSizes),
-                                                                          [vertexSize](uint validVertexSize) {
-                                                                              return vertexSize == validVertexSize;
-                                                                          }) == std::end(validVertexSizes);
-                                                  }) == std::end(attributes);
-
+    const bool vertexBaseTypesAreValid = vertexBaseTypeForAttributesAreValid(attributes);
+    const bool vertexSizesAreValid = vertexSizesForAttributesAreValid(attributes);
     return vertexSizesAreValid && vertexBaseTypesAreValid;
 }
 } // namespace MeshParserUtils

--- a/tests/auto/meshparser/tst_meshparser.cpp
+++ b/tests/auto/meshparser/tst_meshparser.cpp
@@ -123,6 +123,21 @@ private Q_SLOTS:
     {
         // GIVEN
         GLTF2Context context;
+
+        Accessor positionAccessor;
+        positionAccessor.dataSize = 3;
+
+        Accessor normalAccessor;
+        normalAccessor.dataSize = 3;
+
+        Accessor indicesAccessor;
+        indicesAccessor.dataSize = 1;
+        indicesAccessor.type = Qt3DRender::QAttribute::VertexBaseType::UnsignedShort;
+
+        context.addAccessor(normalAccessor);
+        context.addAccessor(positionAccessor);
+        context.addAccessor(indicesAccessor);
+
         MeshParser parser;
 
         QFile file(QStringLiteral(ASSETS "simple_cube.gltf"));


### PR DESCRIPTION
- TEXCOORD_1 and TEXCOORD_2 to Qt3DRender::QAttribute name was missing
- Context was missing accessor info for checkForAssetPipelineEditorProperties
- Rewrote geometryIsGLTF2Valid to make it easier to understand