### PR TITLE
glTF export: support embedding / extracting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ moc_*
 /.qmake.stash
 *.blend1
 config.tests/draco/.obj
+config.tests/draco/draco
+

--- a/src/core/gltf2exporter/copyexportpass_p.cpp
+++ b/src/core/gltf2exporter/copyexportpass_p.cpp
@@ -1,0 +1,102 @@
+/*
+    copyingexportpass_cpp.h
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "copyexportpass_p.h"
+#include "gltf2keys_p.h"
+#include "gltf2exporter_p.h"
+#include "gltf2uri_p.h"
+#include <QJsonArray>
+
+QT_BEGIN_NAMESPACE
+namespace Kuesa {
+
+/*!
+ * \class CopyExportPass
+ * \brief glTF export pass that copies referenced assets in another folder.
+ */
+CopyExportPass::CopyExportPass(const QDir &source, const QDir &destination)
+    : m_basePath(source)
+    , m_destination(destination)
+{
+}
+
+void CopyExportPass::addGeneratedFiles(const QStringList &lst)
+{
+    m_generated << lst;
+}
+
+const QStringList &CopyExportPass::errors() const
+{
+    return m_errors;
+}
+
+void CopyExportPass::copyURIs(QJsonObject &root, QLatin1String key)
+{
+    using namespace GLTF2Import;
+    if (m_basePath == m_destination)
+        return;
+
+    auto array_it = root.find(key);
+    if (array_it == root.end())
+        return;
+
+    const auto &array = array_it->toArray();
+    for (const auto &val : array) {
+        const auto &buffer = val.toObject();
+        const auto uri_it = buffer.find(GLTF2Import::KEY_URI);
+        if (uri_it == buffer.end())
+            continue;
+
+        const auto uri = uri_it->toString();
+        if (Uri::kind(uri) != Uri::Kind::Path)
+            continue;
+
+        if (m_generated.contains(uri))
+            continue;
+
+        QFile srcFile(Uri::localFile(uri_it->toString(), m_basePath));
+        const QFileInfo destFile(m_destination, uri_it->toString());
+
+        if (srcFile.exists()) {
+            // Copy files from the source to the target directory
+            QDir{}.mkpath(destFile.absolutePath());
+
+            const bool ok = srcFile.copy(m_destination.absoluteFilePath(uri_it->toString()));
+            if (!ok) {
+                m_errors << QStringLiteral("Unable to copy %1").arg(uri_it->toString());
+            }
+        } else {
+            m_errors << QStringLiteral("Tried to copy missing file %1").arg(uri_it->toString());
+        }
+    }
+
+    *array_it = array;
+}
+
+} // namespace Kuesa
+QT_END_NAMESPACE

--- a/src/core/gltf2exporter/copyexportpass_p.h
+++ b/src/core/gltf2exporter/copyexportpass_p.h
@@ -1,5 +1,5 @@
 /*
-    draco_prefix_p.h
+    copyingexportpass_p.h
 
     This file is part of Kuesa.
 
@@ -26,26 +26,40 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef KUESA_DRACO_PREFIX_P_H
-#define KUESA_DRACO_PREFIX_P_H
+#ifndef KUESA_GLTF2EXPORTER_COPYINGEXPORTPASS_P_H
+#define KUESA_GLTF2EXPORTER_COPYINGEXPORTPASS_P_H
 
 //
-//  W A R N I N G
-//  -------------
+//  NOTICE
+//  ------
 //
-// This file is not part of the Kuesa API.  It exists for the convenience
-// of other Kuesa classes.  This header file may change from version to
-// version without notice, or even be removed.
-//
-// We mean it.
+// We mean it: this file is not part of the public API and could be
+// modified without notice
 //
 
-#if defined(_WIN32)
+#include <QDir>
+#include <QStringList>
+#include <QJsonObject>
 
-#if defined(ERROR)
-#undef ERROR
-#endif
+QT_BEGIN_NAMESPACE
+namespace Kuesa {
 
-#endif
+class CopyExportPass
+{
+public:
+    CopyExportPass(
+            const QDir &source,
+            const QDir &destination);
 
-#endif // KUESA_DRACO_PREFIX_P_H
+    void addGeneratedFiles(const QStringList &lst);
+    const QStringList &errors() const;
+    void copyURIs(QJsonObject &root, QLatin1String key);
+
+private:
+    QStringList m_errors;
+    QStringList m_generated;
+    QDir m_basePath, m_destination;
+};
+} // namespace Kuesa
+QT_END_NAMESPACE
+#endif // KUESA_GLTF2EXPORTER_COPYINGEXPORTPASS_P_H

--- a/src/core/gltf2exporter/dracocompressor_p.cpp
+++ b/src/core/gltf2exporter/dracocompressor_p.cpp
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Juan Jose Casafranca <juan.casafranca@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
@@ -171,7 +171,7 @@ std::pair<QString, int> addAttributeToMesh(const Qt3DRender::QAttribute &attribu
     draco::PointAttribute meshAttribute;
     meshAttribute.Init(attributeTypeFromName(attribute.name()),
                        nullptr,
-                       static_cast<int8_t>(attribute.vertexSize()),
+                       static_cast<qint8>(attribute.vertexSize()),
                        dracoDataType,
                        false,
                        actualStride<T>(attribute.byteStride(), attribute.vertexSize()),
@@ -216,7 +216,7 @@ template<typename T>
 bool compressAttribute(
         const Qt3DRender::QAttribute &attribute,
         draco::Mesh &dracoMesh,
-        std::vector<std::pair<QString, int>>& attributes)
+        std::vector<std::pair<QString, int>> &attributes)
 {
     auto compressedAttr = addAttributeToMesh<T>(attribute, dracoMesh);
     if (compressedAttr.second == -1) {
@@ -273,43 +273,43 @@ CompressedMesh compressMesh(
 
         switch (attribute->vertexBaseType()) {
         case Qt3DRender::QAttribute::VertexBaseType::Float: {
-            if(!compressAttribute<float>(*attribute, dracoMesh, attributes))
+            if (!compressAttribute<float>(*attribute, dracoMesh, attributes))
                 return {};
             break;
         }
         case Qt3DRender::QAttribute::VertexBaseType::Byte: {
             static_assert (std::numeric_limits<qint8>::min() < 0, "This code only works on platforms with signed char");
-            if(!compressAttribute<qint8>(*attribute, dracoMesh, attributes))
+            if (!compressAttribute<qint8>(*attribute, dracoMesh, attributes))
                 return {};
             break;
         }
         case Qt3DRender::QAttribute::VertexBaseType::UnsignedByte: {
-            if(!compressAttribute<quint8>(*attribute, dracoMesh, attributes))
+            if (!compressAttribute<quint8>(*attribute, dracoMesh, attributes))
                 return {};
             break;
         }
         case Qt3DRender::QAttribute::VertexBaseType::Short: {
-            if(!compressAttribute<qint16>(*attribute, dracoMesh, attributes))
+            if (!compressAttribute<qint16>(*attribute, dracoMesh, attributes))
                 return {};
             break;
         }
         case Qt3DRender::QAttribute::VertexBaseType::UnsignedShort: {
-            if(!compressAttribute<quint16>(*attribute, dracoMesh, attributes))
+            if (!compressAttribute<quint16>(*attribute, dracoMesh, attributes))
                 return {};
             break;
         }
         case Qt3DRender::QAttribute::VertexBaseType::Int: {
-            if(!compressAttribute<qint32>(*attribute, dracoMesh, attributes))
+            if (!compressAttribute<qint32>(*attribute, dracoMesh, attributes))
                 return {};
             break;
         }
         case Qt3DRender::QAttribute::VertexBaseType::UnsignedInt: {
-            if(!compressAttribute<quint32>(*attribute, dracoMesh, attributes))
+            if (!compressAttribute<quint32>(*attribute, dracoMesh, attributes))
                 return {};
             break;
         }
         case Qt3DRender::QAttribute::VertexBaseType::Double: {
-            if(!compressAttribute<double>(*attribute, dracoMesh, attributes))
+            if (!compressAttribute<double>(*attribute, dracoMesh, attributes))
                 return {};
             break;
         }

--- a/src/core/gltf2exporter/dracocompressor_p.h
+++ b/src/core/gltf2exporter/dracocompressor_p.h
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Juan Jose Casafranca <juan.casafranca@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/src/core/gltf2exporter/dracoexportpass_p.cpp
+++ b/src/core/gltf2exporter/dracoexportpass_p.cpp
@@ -1,0 +1,515 @@
+/*
+    dracoexportpass_cpp.h
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "dracoexportpass_p.h"
+#include "gltf2utils_p.h"
+
+QT_BEGIN_NAMESPACE
+
+namespace Kuesa {
+namespace {
+
+struct BufferParts {
+    int offset{};
+    int length{};
+    int stride{};
+    friend bool operator==(BufferParts lhs, BufferParts rhs)
+    {
+        return lhs.offset == rhs.offset;
+    }
+    friend bool operator<(BufferParts lhs, BufferParts rhs)
+    {
+        return lhs.offset < rhs.offset;
+    }
+};
+
+// Maps the new index of an offset in a buffer after removal of prior parts
+int mapBufferOffset(const std::set<BufferParts> &removed_parts, int offset)
+{
+    const auto compare = [](BufferParts lhs, int rhs) { return lhs.offset < rhs; };
+    const auto end = std::lower_bound(
+            removed_parts.begin(), removed_parts.end(), offset, compare);
+
+    for (auto it = removed_parts.begin(); it != end; ++it) {
+        offset -= it->length;
+    }
+
+    return offset;
+}
+
+// Given an accessor array, remove their "bufferView": key, and return the corresponding set of
+// bufferViews
+std::set<int> cleanAccessors(QJsonArray &accessors, const std::set<int> &indices)
+{
+    std::set<int> bufferViews;
+    for (int accessor : indices) {
+        auto acc = accessors[accessor].toObject();
+        auto it = acc.find(GLTF2Import::KEY_BUFFERVIEW);
+        if (it != acc.end()) {
+            bufferViews.insert(it.value().toInt());
+            acc.erase(it);
+
+            acc.remove(GLTF2Import::KEY_BYTEOFFSET);
+        }
+        accessors[accessor] = std::move(acc);
+    }
+    return bufferViews;
+}
+} // namespace
+
+DracoExportPass::DracoExportPass(
+        const QString &sourceFilename,
+        const QDir &source, const QDir &destination,
+        const QJsonObject &rootObject,
+        const GLTF2ExportConfiguration &conf,
+        GLTF2Import::GLTF2Context &context)
+    : m_root(rootObject)
+    , m_buffers(rootObject[GLTF2Import::KEY_BUFFERS].toArray())
+    , m_bufferViews(rootObject[GLTF2Import::KEY_BUFFERVIEWS].toArray())
+    , m_accessors(rootObject[GLTF2Import::KEY_ACCESSORS].toArray())
+    , m_meshes(rootObject[GLTF2Import::KEY_MESHES].toArray())
+    , m_images(rootObject[GLTF2Import::KEY_IMAGES].toArray())
+    , m_compressedBufferIndex(m_buffers.size()) // Index of the added buffer
+    , m_newBufferViewIndex(m_bufferViews.size()) // Index of where the bufferViews are added
+    , m_basePath(source)
+    , m_destination(destination)
+    , m_conf(conf)
+    , m_context(context)
+{
+    switch (m_conf.embedding()) {
+    case GLTF2ExportConfiguration::Embed::All: {
+        break;
+    }
+    case GLTF2ExportConfiguration::Embed::Keep:
+    case GLTF2ExportConfiguration::Embed::None: {
+        QString basename = QFileInfo(sourceFilename).baseName();
+        if (basename.isEmpty())
+            basename = QStringLiteral("compressedBuffer.bin");
+
+        m_compressedBufferFilename = generateUniqueFilename(m_basePath, QStringLiteral("%1.bin").arg(basename));
+        break;
+    }
+    }
+}
+
+const QString &DracoExportPass::compressedBufferFilename() const
+{
+    return m_compressedBufferFilename;
+}
+
+QJsonObject DracoExportPass::compress()
+{
+    // https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md
+
+    // 1. Compress all the meshes
+    for (int i = 0, n = m_context.meshesCount(); i < n; ++i) {
+        const auto mesh_json = m_meshes[i].toObject();
+        m_meshes[i] = compressMesh(mesh_json, i);
+    }
+
+    if (m_compressedBuffer.isEmpty()) {
+        return m_root; // Nothing changed
+    }
+
+    // 2. Save all the compressed data in a monolithic buffer and add it to the buffer list
+    {
+        QString uri;
+        switch (m_conf.embedding()) {
+        case GLTF2ExportConfiguration::Embed::All: {
+            uri = QString::fromLatin1(GLTF2Import::Uri::toBase64Uri(m_compressedBuffer));
+            break;
+        }
+        case GLTF2ExportConfiguration::Embed::Keep:
+        case GLTF2ExportConfiguration::Embed::None: {
+            uri = m_compressedBufferFilename;
+            QFile compressedBufferFile(m_destination.filePath({ m_compressedBufferFilename }));
+            if (compressedBufferFile.open(QIODevice::WriteOnly)) {
+                compressedBufferFile.write(m_compressedBuffer);
+                compressedBufferFile.close();
+            } else {
+                m_errors << QStringLiteral("Could not open %1 for writing.").arg(compressedBufferFile.fileName());
+                return {};
+            }
+            break;
+        }
+        }
+
+        QJsonObject compressedBufferObject;
+        compressedBufferObject[GLTF2Import::KEY_BYTELENGTH] = m_compressedBuffer.size();
+        compressedBufferObject[GLTF2Import::KEY_URI] = std::move(uri);
+        m_buffers.push_back(compressedBufferObject);
+    }
+
+    // 3. Adjust the accessors: they don't need to point to a bufferView anymore since it's the Draco extension which is aware of them
+    // TODO what happens if an accessor was referred by a mesh but also something else ?
+    std::set<int> bufferViews_to_clean = cleanAccessors(m_accessors, m_accessorsToClean);
+
+    // 4. Remove the data from the buffers and adjust the remaining bufferViews
+    // We have to update *all* the indices everywhere - not only for meshes.
+    removeBufferViews(bufferViews_to_clean);
+
+    // 5. Finalize the JSON
+    replaceJsonArray(m_root, GLTF2Import::KEY_BUFFERS, m_buffers);
+    replaceJsonArray(m_root, GLTF2Import::KEY_BUFFERVIEWS, m_bufferViews);
+    replaceJsonArray(m_root, GLTF2Import::KEY_ACCESSORS, m_accessors);
+    replaceJsonArray(m_root, GLTF2Import::KEY_MESHES, m_meshes);
+    replaceJsonArray(m_root, GLTF2Import::KEY_IMAGES, m_images);
+
+    addExtension(m_root, GLTF2Import::KEY_EXTENSIONS_REQUIRED, GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION);
+    addExtension(m_root, GLTF2Import::KEY_EXTENSIONS_USED, GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION);
+
+    return m_root;
+}
+
+QJsonObject DracoExportPass::compressMesh(QJsonObject mesh_json, int mesh_idx)
+{
+    const auto &primitives = m_context.mesh(mesh_idx).meshPrimitives;
+    auto primitives_json = mesh_json[GLTF2Import::KEY_PRIMITIVES].toArray();
+
+    Q_ASSERT_X(primitives_json.size() == primitives.size(), "GLTF2DracoCompressor::compressMesh", "Bad primitive count");
+
+    for (int p = 0; p < primitives_json.size(); ++p) {
+        auto primitive_json = primitives_json[p].toObject();
+
+        // First check if the primitive is already draco-compressed
+        auto ext_it = primitive_json.find(GLTF2Import::KEY_EXTENSIONS);
+        if (ext_it != primitive_json.end()) {
+            auto ext = ext_it->toObject();
+            if (ext.contains(GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION)) {
+                continue;
+            }
+        }
+
+        auto compressed_mesh = compressPrimitive(
+                primitive_json,
+                primitives[p]);
+
+        if (!compressed_mesh.primitiveJson.empty()) {
+            //* all the side-effects of this method are in this block: */
+            primitives_json[p] = compressed_mesh.primitiveJson;
+            m_compressedBuffer.push_back(compressed_mesh.compressedData);
+            m_bufferViews.push_back(compressed_mesh.newBufferView);
+            m_accessorsToClean.insert(compressed_mesh.accessorsToClean.begin(), compressed_mesh.accessorsToClean.end());
+
+            ++m_newBufferViewIndex;
+        } else {
+            const auto meshName = mesh_json[GLTF2Import::KEY_NAME].toString();
+            if (!meshName.isEmpty())
+                m_errors << QStringLiteral("A mesh could not be compressed: %1 -> %2").arg(meshName).arg(p);
+            else
+                m_errors << QStringLiteral("A mesh could not be compressed: %1 -> %2").arg(mesh_idx).arg(p);
+        }
+    }
+
+    mesh_json[GLTF2Import::KEY_PRIMITIVES] = std::move(primitives_json);
+    return mesh_json;
+}
+
+DracoExportPass::CompressedGLTFPrimitive DracoExportPass::compressPrimitive(
+        QJsonObject primitive_json,
+        GLTF2Import::Primitive primitive) const
+{
+    CompressedGLTFPrimitive compressed_primitive;
+
+    // Do the compression
+    const auto compressed = Kuesa::DracoCompression::compressMesh(*primitive.primitiveRenderer->geometry(), m_conf);
+    if (!compressed.buffer)
+        return {};
+
+    const int offset = m_compressedBuffer.size();
+    auto &eb = *compressed.buffer.get();
+    const int eb_size = static_cast<int>(eb.size());
+
+    compressed_primitive.compressedData = QByteArray{ eb.data(), eb_size };
+
+    // For now we allocate new bufferViews per compressed chunk; then we should do a pass to remove / replace unused bv ?
+
+    // Allocate a new buffer view
+    {
+        compressed_primitive.newBufferView[GLTF2Import::KEY_BUFFER] = m_compressedBufferIndex;
+        compressed_primitive.newBufferView[GLTF2Import::KEY_BYTEOFFSET] = offset;
+        compressed_primitive.newBufferView[GLTF2Import::KEY_BYTELENGTH] = eb_size;
+    }
+
+    // Create or modify the extension object
+    {
+        auto ext_obj = primitive_json[GLTF2Import::KEY_EXTENSIONS].toObject();
+
+        {
+            QJsonObject draco_ext;
+            draco_ext[GLTF2Import::KEY_BUFFERVIEW] = m_newBufferViewIndex;
+
+            QJsonObject draco_ext_attr;
+            for (const auto &attribute : compressed.attributes) {
+                draco_ext_attr[attribute.first] = attribute.second;
+            }
+            draco_ext[GLTF2Import::KEY_ATTRIBUTES] = draco_ext_attr;
+
+            ext_obj[GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION] = draco_ext;
+        }
+
+        primitive_json[GLTF2Import::KEY_EXTENSIONS] = ext_obj;
+    }
+
+    // Mark the primitive's accessors
+    {
+        auto it = primitive_json.find(GLTF2Import::KEY_INDICES);
+        if (it != primitive_json.end() && it->isDouble()) {
+            compressed_primitive.accessorsToClean.insert(it->toInt());
+        }
+
+        it = primitive_json.find(GLTF2Import::KEY_ATTRIBUTES);
+        if (it != primitive_json.end() && it->isObject()) {
+            const auto attributes = it->toObject();
+            for (const auto &attr : attributes) {
+                if (attr.isDouble())
+                    compressed_primitive.accessorsToClean.insert(attr.toInt());
+            }
+        }
+    }
+    compressed_primitive.primitiveJson = primitive_json;
+
+    return compressed_primitive;
+}
+
+void DracoExportPass::removeBufferViews(const std::set<int> &indicesToRemove)
+{
+    // First compute the new indices of the buffer views
+    std::map<int, int> bufferViewIndex;
+    int currentOffset = 0;
+    for (int i = 0, n = m_bufferViews.size(); i < n; ++i) {
+        if (indicesToRemove.count(i) != 0) {
+            ++currentOffset;
+        }
+        bufferViewIndex[i] = i - currentOffset;
+    }
+
+    auto updateExistingIndex = [&](QJsonObject &obj, QLatin1String key) {
+        auto it = obj.find(key);
+        if (it != obj.end()) {
+            it.value() = bufferViewIndex.at(it.value().toInt());
+        }
+    };
+
+    // Fix them in the accessors
+    for (int i = 0; i < m_accessors.size(); ++i) {
+        auto acc = m_accessors[i].toObject();
+
+        updateExistingIndex(acc, GLTF2Import::KEY_BUFFERVIEW);
+
+        {
+            auto it = acc.find(GLTF2Import::KEY_SPARSE);
+            if (it != acc.end()) {
+                auto sparse = it->toObject();
+                {
+                    auto indices = sparse.value(GLTF2Import::KEY_INDICES).toObject();
+                    updateExistingIndex(indices, GLTF2Import::KEY_BUFFERVIEW);
+                    sparse[GLTF2Import::KEY_INDICES] = std::move(indices);
+                }
+                {
+                    auto values = sparse.value(GLTF2Import::KEY_VALUES).toObject();
+                    updateExistingIndex(values, GLTF2Import::KEY_BUFFERVIEW);
+                    sparse[GLTF2Import::KEY_VALUES] = std::move(values);
+                }
+                *it = std::move(sparse);
+            }
+        }
+
+        m_accessors[i] = std::move(acc);
+    }
+
+    // Fix them in the meshes
+    for (int i = 0; i < m_meshes.size(); ++i) {
+        auto mesh = m_meshes[i].toObject();
+        auto primitives = mesh[GLTF2Import::KEY_PRIMITIVES].toArray();
+        for (int p = 0; p < primitives.size(); ++p) {
+            auto primitive = primitives[p].toObject();
+
+            auto ext_it = primitive.find(GLTF2Import::KEY_EXTENSIONS);
+            if (ext_it != primitive.end()) {
+                auto ext = ext_it->toObject();
+
+                auto draco_it = ext.find(GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION);
+                if (draco_it != ext.end()) {
+                    auto draco = draco_it->toObject();
+                    updateExistingIndex(draco, GLTF2Import::KEY_BUFFERVIEW);
+                    *draco_it = std::move(draco);
+                }
+
+                *ext_it = std::move(ext);
+            }
+
+            primitives[p] = std::move(primitive);
+        }
+        mesh[GLTF2Import::KEY_PRIMITIVES] = std::move(primitives);
+        m_meshes[i] = std::move(mesh);
+    }
+
+    // Fix them in the images
+    for (int i = 0; i < m_images.size(); ++i) {
+        auto img = m_images[i].toObject();
+        updateExistingIndex(img, GLTF2Import::KEY_BUFFERVIEW);
+        m_images[i] = std::move(img);
+    }
+
+    // Remove the buffer views
+    QJsonArray removedBufferViews;
+    // (note: this loop could be merged with the earlier one
+    // but this would be a bit less readable imho)
+    for (auto it = indicesToRemove.rbegin(); it != indicesToRemove.rend(); ++it) {
+        auto bv_it = m_bufferViews.begin() + (*it);
+
+        removedBufferViews.push_back(std::move(*bv_it));
+        m_bufferViews.erase(bv_it);
+    }
+
+    cleanupBuffers(removedBufferViews);
+}
+
+void DracoExportPass::cleanupBuffers(const QJsonArray &removedBufferViews)
+{
+    using namespace GLTF2Import;
+    std::map<int, std::set<BufferParts>> bufferParts;
+    // List and order all the parts of the buffers to remove
+    for (const QJsonValue &bv_value : removedBufferViews) {
+        const auto bv = bv_value.toObject();
+        const auto it = bv.find(GLTF2Import::KEY_BUFFER);
+        if (it != bv.end()) {
+            const int buffer_idx = it.value().toInt();
+            const auto buf = m_buffers[buffer_idx].toObject();
+            const auto uri = buf[GLTF2Import::KEY_URI].toString();
+            const bool is_embedded = Uri::kind(uri) == Uri::Kind::Data;
+
+            if (is_embedded || QFileInfo::exists(Uri::localFile(uri, m_basePath))) {
+                BufferParts p;
+                p.offset = bv[GLTF2Import::KEY_BYTEOFFSET].toInt();
+                p.length = bv[GLTF2Import::KEY_BYTELENGTH].toInt();
+                p.stride = bv[GLTF2Import::KEY_BYTESTRIDE].toInt();
+
+                bufferParts[buffer_idx].insert(p);
+            } else {
+                m_errors << QStringLiteral("File does not exist: %1").arg(uri);
+            }
+        }
+    }
+
+    // Remove the parts in the buffers
+    std::vector<int> buffersToRemove;
+
+    // TODO we should check that all buffer objects map to a unique file
+    // else this won't work at all
+    for (const auto &buffer : bufferParts) {
+        QJsonObject buf = m_buffers[buffer.first].toObject();
+
+        const auto uri = buf[GLTF2Import::KEY_URI].toString();
+        const bool is_embedded = Uri::kind(uri) == Uri::Kind::Data;
+        const bool must_embed = is_embedded || m_conf.embedding() == GLTF2ExportConfiguration::Embed::All;
+
+        bool success = false;
+        auto data = Uri::fetchData(uri, m_basePath, success);
+        if (!success) {
+            if (is_embedded)
+                m_errors << QStringLiteral("Could not read embedded buffer");
+            else
+                m_errors << QStringLiteral("Could not read %1").arg(m_basePath.absoluteFilePath(uri));
+            continue;
+        }
+
+        int removed_length = 0;
+
+        // TODO handle overlapping bufferViews
+        // TODO handle strided buffers
+        for (auto it = buffer.second.rbegin(); it != buffer.second.rend(); ++it) {
+            data.remove(it->offset, it->length);
+            removed_length += it->length;
+        }
+
+        if (data.isEmpty()) {
+            // Actually we could precompute this case...
+            buffersToRemove.push_back(buffer.first);
+        } else {
+            if (!is_embedded && !must_embed) {
+                QDir{}.mkpath(QFileInfo(m_destination, uri).absolutePath());
+                QFile target_f(m_destination.filePath(uri));
+                if (!target_f.open(QIODevice::WriteOnly)) {
+                    m_errors << QStringLiteral("Could not open %1 for writing").arg(target_f.fileName());
+                    continue;
+                }
+                const auto written = target_f.write(data);
+                if (written != data.size()) {
+                    m_errors << QStringLiteral("Could not write buffer %1 entirely").arg(target_f.fileName());
+                    continue;
+                }
+            } else {
+                buf[GLTF2Import::KEY_URI] = QString::fromLatin1(GLTF2Import::Uri::toBase64Uri(data));
+            }
+
+            const auto len_it = buf.find(GLTF2Import::KEY_BYTELENGTH);
+            if (len_it != buf.end()) {
+                (*len_it) = len_it->toInt() - removed_length;
+            }
+
+            m_buffers[buffer.first] = std::move(buf);
+        }
+    }
+
+    // Change the offsets in the bufferViews
+    for (auto bv_it = m_bufferViews.begin(); bv_it != m_bufferViews.end(); ++bv_it) {
+        auto bv = bv_it->toObject();
+        auto it = bv.find(GLTF2Import::KEY_BUFFER);
+        if (it != bv.end()) {
+            const int buffer_idx = it.value().toInt();
+
+            // Change the offset of the data in the buffer
+            auto offset_it = bv.find(GLTF2Import::KEY_BYTEOFFSET);
+            (*offset_it) = mapBufferOffset(bufferParts[buffer_idx], offset_it->toInt());
+
+            // Change the buffer index if there are removed buffers
+            int new_buffer_idx = buffer_idx;
+            for (int removed_buf : buffersToRemove) {
+                if (removed_buf < buffer_idx)
+                    new_buffer_idx--;
+                else
+                    break;
+            }
+            (*it) = new_buffer_idx;
+            (*bv_it) = std::move(bv);
+        }
+    }
+
+    // Remove unused buffers
+    for (int buffer : buffersToRemove) {
+        m_buffers.erase(m_buffers.begin() + buffer);
+    }
+
+    // TODO Do a final pass to check if there are any unreferenced buffers
+    // Or it could maybe be an additional "lint" pass not part of the draco one ?
+}
+
+} // namespace Kuesa
+QT_END_NAMESPACE

--- a/src/core/gltf2exporter/dracoexportpass_p.h
+++ b/src/core/gltf2exporter/dracoexportpass_p.h
@@ -1,0 +1,117 @@
+/*
+    dracoexportpass_p.h
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef KUESA_GLTF2EXPORTER_DRACOEXPORTPASS_P_H
+#define KUESA_GLTF2EXPORTER_DRACOEXPORTPASS_P_H
+
+//
+//  NOTICE
+//  ------
+//
+// We mean it: this file is not part of the public API and could be
+// modified without notice
+//
+
+#include <qtkuesa-config.h>
+#if defined(KUESA_DRACO_COMPRESSION)
+#include <draco/compression/encode.h>
+
+#include "embedexportpass_p.h"
+#include "dracocompressor_p.h"
+#include "gltf2exporter_p.h"
+#include "gltf2keys_p.h"
+#include "gltf2uri_p.h"
+#include "gltf2importer.h"
+#include "gltf2context_p.h"
+#include <SceneEntity>
+#include "kuesa_p.h"
+
+#include <set>
+
+QT_BEGIN_NAMESPACE
+namespace Kuesa {
+class DracoExportPass
+{
+public:
+    DracoExportPass(
+            const QString &sourceFilename,
+            const QDir &source,
+            const QDir &destination,
+            const QJsonObject &rootObject,
+            const GLTF2ExportConfiguration &conf,
+            GLTF2Import::GLTF2Context &context);
+
+    const QString &compressedBufferFilename() const;
+
+    QJsonObject compress();
+
+private:
+    struct CompressedGLTFPrimitive {
+        QJsonObject primitiveJson;
+        QByteArray compressedData;
+        QJsonObject newBufferView;
+        std::set<int> accessorsToClean;
+    };
+
+    QStringList m_errors;
+
+    QJsonObject m_root;
+    QJsonArray m_buffers;
+    QJsonArray m_bufferViews;
+    QJsonArray m_accessors;
+    QJsonArray m_meshes;
+    QJsonArray m_images;
+
+    QByteArray m_compressedBuffer;
+    const int m_compressedBufferIndex;
+    int m_newBufferViewIndex;
+    std::set<int> m_accessorsToClean;
+    QDir m_basePath, m_destination;
+    QString m_compressedBufferFilename;
+
+    const GLTF2ExportConfiguration &m_conf;
+    GLTF2Import::GLTF2Context &m_context;
+
+    // Compress a single mesh
+    QJsonObject compressMesh(QJsonObject mesh_json, int mesh_idx);
+
+    // Compress a single primitive of a mesh
+    CompressedGLTFPrimitive compressPrimitive(
+            QJsonObject primitive_json, GLTF2Import::Primitive primitive) const;
+
+    void removeBufferViews(const std::set<int> &indicesToRemove);
+
+    // Removes the unused data in buffers
+    void cleanupBuffers(const QJsonArray &removedBufferViews);
+};
+
+} // namespace Kuesa
+QT_END_NAMESPACE
+
+#endif // KUESA_DRACO_COMPRESSION
+#endif // KUESA_GLTF2EXPORTER_DRACOEXPORTPASS_P_H

--- a/src/core/gltf2exporter/embedexportpass_p.cpp
+++ b/src/core/gltf2exporter/embedexportpass_p.cpp
@@ -1,0 +1,90 @@
+/*
+    embeddingexportpass_cpp.h
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "embedexportpass_p.h"
+#include "gltf2keys_p.h"
+#include "gltf2exporter_p.h"
+#include "gltf2uri_p.h"
+#include <QJsonArray>
+
+QT_BEGIN_NAMESPACE
+namespace Kuesa {
+
+/*!
+ * \class EmbedExportPass
+ * \brief glTF export pass that embeds referenced assets as base64 buffers in the glTF file.
+ */
+EmbedExportPass::EmbedExportPass(const QDir &source)
+    : m_basePath(source)
+{
+}
+
+const QStringList &EmbedExportPass::errors() const
+{
+    return m_errors;
+}
+
+void EmbedExportPass::embedURIsInArray(QJsonObject &root, QLatin1String key)
+{
+    auto array_it = root.find(key);
+    if (array_it == root.end())
+        return;
+
+    auto array = array_it->toArray();
+    for (QJsonValueRef val_v : array) {
+        auto obj = val_v.toObject();
+        if (embedUri(obj)) {
+            val_v = obj;
+        }
+    }
+    *array_it = array;
+}
+
+bool EmbedExportPass::embedUri(QJsonObject &object)
+{
+    using namespace GLTF2Import;
+    const auto uri_it = object.find(GLTF2Import::KEY_URI);
+    if (uri_it == object.end())
+        return false;
+
+    const auto &uri = uri_it->toString();
+    if (Uri::kind(uri) != Uri::Kind::Path)
+        return false;
+
+    QFile resource(Uri::localFile(uri, m_basePath));
+    if (!resource.open(QIODevice::ReadOnly)) {
+        m_errors << QStringLiteral("Cannot open: %1").arg(uri);
+        return false;
+    }
+
+    *uri_it = QString::fromLatin1(GLTF2Import::Uri::toBase64Uri(resource.readAll()));
+    return true;
+}
+
+} // namespace Kuesa
+QT_END_NAMESPACE

--- a/src/core/gltf2exporter/embedexportpass_p.h
+++ b/src/core/gltf2exporter/embedexportpass_p.h
@@ -1,5 +1,5 @@
 /*
-    draco_prefix_p.h
+    embeddingexportpass_p.h
 
     This file is part of Kuesa.
 
@@ -26,26 +26,42 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef KUESA_DRACO_PREFIX_P_H
-#define KUESA_DRACO_PREFIX_P_H
+#ifndef KUESA_GLTF2EXPORTER_EMBEDDINGEXPORTPASS_P_H
+#define KUESA_GLTF2EXPORTER_EMBEDDINGEXPORTPASS_P_H
 
 //
-//  W A R N I N G
-//  -------------
+//  NOTICE
+//  ------
 //
-// This file is not part of the Kuesa API.  It exists for the convenience
-// of other Kuesa classes.  This header file may change from version to
-// version without notice, or even be removed.
-//
-// We mean it.
+// We mean it: this file is not part of the public API and could be
+// modified without notice
 //
 
-#if defined(_WIN32)
+#include <QDir>
+#include <QStringList>
+#include <QJsonObject>
 
-#if defined(ERROR)
-#undef ERROR
-#endif
+QT_BEGIN_NAMESPACE
+namespace Kuesa {
 
-#endif
+class EmbedExportPass
+{
+public:
+    EmbedExportPass(
+            const QDir &source);
 
-#endif // KUESA_DRACO_PREFIX_P_H
+    const QStringList &errors() const;
+
+    void embedURIsInArray(QJsonObject &root, QLatin1String key);
+
+private:
+    bool embedUri(QJsonObject &object);
+
+    QStringList m_errors;
+
+    QDir m_basePath;
+};
+} // namespace Kuesa
+QT_END_NAMESPACE
+
+#endif // KUESA_GLTF2EXPORTER_EMBEDDINGEXPORTPASS_P_H

--- a/src/core/gltf2exporter/gltf2exporter.pri
+++ b/src/core/gltf2exporter/gltf2exporter.pri
@@ -2,7 +2,7 @@
 #
 # This file is part of Kuesa.
 #
-# Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 # Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 #
 # Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
@@ -27,15 +27,26 @@
 INCLUDEPATH += $$PWD
 
 SOURCES += \
-    $$PWD/gltf2exporter_p.cpp
+    $$PWD/copyexportpass_p.cpp \
+    $$PWD/embedexportpass_p.cpp \
+    $$PWD/gltf2exporter_p.cpp \
+    $$PWD/gltf2utils_p.cpp \
+    $$PWD/separateexportpass_p.cpp
 
 HEADERS += \
-    $$PWD/gltf2exporter_p.h
+    $$PWD/copyexportpass_p.h \
+    $$PWD/embedexportpass_p.h \
+    $$PWD/gltf2exporter_p.h \
+    $$PWD/gltf2utils_p.h \
+    $$PWD/separateexportpass_p.h
 
 qtConfig(draco) {
     SOURCES += \
-      $$PWD/dracocompressor_p.cpp
+      $$PWD/dracocompressor_p.cpp \
+      $$PWD/dracoexportpass_p.cpp
+
     HEADERS +=\
-      $$PWD/dracocompressor_p.h
+      $$PWD/dracocompressor_p.h \
+      $$PWD/dracoexportpass_p.h
 }
 

--- a/src/core/gltf2exporter/gltf2exporter_p.cpp
+++ b/src/core/gltf2exporter/gltf2exporter_p.cpp
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
@@ -31,19 +31,18 @@
 #include <Kuesa/private/draco_prefix_p.h>
 #include <draco/compression/encode.h>
 #include "dracocompressor_p.h"
+#include "dracoexportpass_p.h"
 #endif
+#include "embedexportpass_p.h"
+#include "separateexportpass_p.h"
+#include "copyexportpass_p.h"
 
-#include <QFile>
-#include <SceneEntity>
+#include "gltf2importer.h"
 #include "gltf2exporter_p.h"
 #include "gltf2context_p.h"
-#include "gltf2keys_p.h"
-#include "gltf2uri_p.h"
-#include "gltf2importer.h"
 #include "kuesa_p.h"
-#include <set>
-#include <Kuesa/private/gltf2context_p.h>
 
+#include <QFile>
 QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
@@ -52,7 +51,6 @@ class QGeometry;
 } // namespace Qt3DRender
 
 namespace Kuesa {
-namespace {
 
 QString generateUniqueFilename(const QDir &dir, QString filename)
 {
@@ -66,7 +64,6 @@ QString generateUniqueFilename(const QDir &dir, QString filename)
     }
     return filename;
 }
-} // namespace
 
 void GLTF2ExportConfiguration::setMeshEncodingSpeed(int speed)
 {
@@ -118,519 +115,15 @@ bool GLTF2ExportConfiguration::meshCompressionEnabled() const
     return m_meshCompression;
 }
 
-namespace {
-#if defined(KUESA_DRACO_COMPRESSION)
-class GLTF2DracoCompressor
+auto GLTF2ExportConfiguration::embedding() const -> Embed
 {
-public:
-    GLTF2DracoCompressor(
-            QDir source,
-            QDir destination,
-            const QJsonObject &rootObject,
-            const GLTF2ExportConfiguration &conf,
-            GLTF2Import::GLTF2Context &context)
-        : m_root(rootObject)
-        , m_buffers(rootObject[GLTF2Import::KEY_BUFFERS].toArray())
-        , m_bufferViews(rootObject[GLTF2Import::KEY_BUFFERVIEWS].toArray())
-        , m_accessors(rootObject[GLTF2Import::KEY_ACCESSORS].toArray())
-        , m_meshes(rootObject[GLTF2Import::KEY_MESHES].toArray())
-        , m_images(rootObject[GLTF2Import::KEY_IMAGES].toArray())
-        , m_compressedBufferIndex(m_buffers.size()) // Index of the added buffer
-        , m_newBufferViewIndex(m_bufferViews.size()) // Index of where the bufferView are added
-        , m_basePath(source)
-        , m_destination(destination)
-        , m_compressedBufferFilename(generateUniqueFilename(m_basePath, QStringLiteral("compressedBuffer.bin")))
-        , m_conf(conf)
-        , m_context(context)
-    {
-    }
-
-    const QString &compressedBufferFilename() const noexcept
-    {
-        return m_compressedBufferFilename;
-    }
-
-    QJsonObject compress()
-    {
-        // https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md
-
-        // 1. Compress all the meshes
-        for (int i = 0, n = m_context.meshesCount(); i < n; i++) {
-            const auto mesh_json = m_meshes[i].toObject();
-            m_meshes[i] = compressMesh(mesh_json, i);
-        }
-
-        if (m_compressedBuffer.isEmpty()) {
-            return m_root; // Nothing changed
-        }
-
-        // 2. Save all the compressed data in a monolithic buffer and add it to the buffer list
-        {
-            // TODO maybe warn the user of unused assets ?
-            QFile compressedBufferFile(m_destination.filePath({ m_compressedBufferFilename }));
-            if (compressedBufferFile.open(QIODevice::WriteOnly)) {
-                compressedBufferFile.write(m_compressedBuffer);
-                compressedBufferFile.close();
-            } else {
-                m_errors << QStringLiteral("Could not open %1 for writing.").arg(compressedBufferFile.fileName());
-                return {};
-            }
-
-            QJsonObject compressedBufferObject;
-            compressedBufferObject[GLTF2Import::KEY_BYTELENGTH] = m_compressedBuffer.size();
-            compressedBufferObject[GLTF2Import::KEY_URI] = m_compressedBufferFilename;
-            m_buffers.push_back(compressedBufferObject);
-        }
-
-        // 3. Adjust the accessors: they don't need to point to a bufferView anymore since it's the Draco extension which is aware of them
-        // TODO what happens if an accessor was referred by a mesh but also something else ?
-        std::set<int> bufferViews_to_clean = cleanAccessors(m_accessors, m_accessorsToClean);
-
-        // 4. Remove the data from the buffers and adjust the remaining bufferViews
-        // We have to update *all* the indices everywhere - not only for meshes.
-        removeBufferViews(bufferViews_to_clean);
-
-        // 5. Finalize the JSON
-        auto replace_json = [&](QJsonObject &m_root, const QLatin1String &k, QJsonArray &arr) {
-            auto it = m_root.find(k);
-            if (it != m_root.end() && arr.empty())
-                m_root.erase(it);
-            else if (!arr.empty())
-                *it = std::move(arr);
-        };
-        replace_json(m_root, GLTF2Import::KEY_BUFFERS, m_buffers);
-        replace_json(m_root, GLTF2Import::KEY_BUFFERVIEWS, m_bufferViews);
-        replace_json(m_root, GLTF2Import::KEY_ACCESSORS, m_accessors);
-        replace_json(m_root, GLTF2Import::KEY_MESHES, m_meshes);
-        replace_json(m_root, GLTF2Import::KEY_IMAGES, m_images);
-
-        addExtension(m_root, GLTF2Import::KEY_EXTENSIONS_REQUIRED, GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION);
-        addExtension(m_root, GLTF2Import::KEY_EXTENSIONS_USED, GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION);
-
-        return m_root;
-    }
-
-private:
-    struct CompressedGLTFPrimitive {
-        QJsonObject primitiveJson;
-        QByteArray compressedData;
-        QJsonObject newBufferView;
-        std::set<int> accessorsToClean;
-    };
-
-    QStringList m_errors;
-
-    QJsonObject m_root;
-    QJsonArray m_buffers;
-    QJsonArray m_bufferViews;
-    QJsonArray m_accessors;
-    QJsonArray m_meshes;
-    QJsonArray m_images;
-
-    QByteArray m_compressedBuffer;
-    const int m_compressedBufferIndex;
-    int m_newBufferViewIndex;
-    std::set<int> m_accessorsToClean;
-    QDir m_basePath, m_destination;
-    QString m_compressedBufferFilename;
-
-    const GLTF2ExportConfiguration &m_conf;
-    GLTF2Import::GLTF2Context &m_context;
-
-    // Compress a single mesh
-    QJsonObject compressMesh(QJsonObject mesh_json, int mesh_idx)
-    {
-        const auto &primitives = m_context.mesh(mesh_idx).meshPrimitives;
-        auto primitives_json = mesh_json[GLTF2Import::KEY_PRIMITIVES].toArray();
-
-        Q_ASSERT_X(primitives_json.size() == primitives.size(), "GLTF2DracoCompressor::compressMesh", "Bad primitive count");
-
-        for (int p = 0; p < primitives_json.size(); ++p) {
-            auto primitive_json = primitives_json[p].toObject();
-
-            // First check if the primitive is already draco-compressed
-            auto ext_it = primitive_json.find(GLTF2Import::KEY_EXTENSIONS);
-            if (ext_it != primitive_json.end()) {
-                auto ext = ext_it->toObject();
-                if (ext.contains(GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION)) {
-                    continue;
-                }
-            }
-
-            auto compressed_mesh = compressPrimitive(
-                    primitive_json,
-                    primitives[p]);
-
-            if (!compressed_mesh.primitiveJson.empty()) {
-                //* all the side-effects of this method are in this block: */
-                primitives_json[p] = compressed_mesh.primitiveJson;
-                m_compressedBuffer.push_back(compressed_mesh.compressedData);
-                m_bufferViews.push_back(compressed_mesh.newBufferView);
-                m_accessorsToClean.insert(compressed_mesh.accessorsToClean.begin(), compressed_mesh.accessorsToClean.end());
-
-                m_newBufferViewIndex++;
-            } else {
-                const auto meshName = mesh_json[GLTF2Import::KEY_NAME].toString();
-                if (!meshName.isEmpty())
-                    m_errors << QStringLiteral("A mesh could not be compressed: %1 -> %2").arg(meshName).arg(p);
-                else
-                    m_errors << QStringLiteral("A mesh could not be compressed: %1 -> %2").arg(mesh_idx).arg(p);
-            }
-        }
-
-        mesh_json[GLTF2Import::KEY_PRIMITIVES] = std::move(primitives_json);
-        return mesh_json;
-    }
-
-    // Compress a single primitive of a mesh
-    CompressedGLTFPrimitive compressPrimitive(
-            QJsonObject primitive_json, const Kuesa::GLTF2Import::Primitive &primitive) const
-    {
-        CompressedGLTFPrimitive compressed_primitive;
-
-        // Do the compression
-        const auto compressed = Kuesa::DracoCompression::compressMesh(*primitive.primitiveRenderer->geometry(), m_conf);
-        if (!compressed.buffer)
-            return {};
-
-        const int offset = m_compressedBuffer.size();
-        auto &eb = *compressed.buffer.get();
-        const int eb_size = static_cast<int>(eb.size());
-
-        compressed_primitive.compressedData = QByteArray{ eb.data(), eb_size };
-
-        // For now we allocate new bufferViews per compressed chunk; then we should do a pass to remove / replace unused bv ?
-
-        // Allocate a new buffer view
-        {
-            compressed_primitive.newBufferView[GLTF2Import::KEY_BUFFER] = m_compressedBufferIndex;
-            compressed_primitive.newBufferView[GLTF2Import::KEY_BYTEOFFSET] = offset;
-            compressed_primitive.newBufferView[GLTF2Import::KEY_BYTELENGTH] = eb_size;
-        }
-
-        // Create or modify the extension object
-        {
-            auto ext_obj = primitive_json[GLTF2Import::KEY_EXTENSIONS].toObject();
-
-            {
-                QJsonObject draco_ext;
-                draco_ext[GLTF2Import::KEY_BUFFERVIEW] = m_newBufferViewIndex;
-                {
-                    QJsonObject draco_ext_attr;
-                    for (const auto &attribute : compressed.attributes) {
-                        draco_ext_attr[attribute.first] = attribute.second;
-                    }
-                    draco_ext[GLTF2Import::KEY_ATTRIBUTES] = draco_ext_attr;
-                }
-
-                ext_obj[GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION] = draco_ext;
-            }
-
-            primitive_json[GLTF2Import::KEY_EXTENSIONS] = ext_obj;
-        }
-
-        // Mark the primitive's accessors
-        {
-            auto it = primitive_json.find(GLTF2Import::KEY_INDICES);
-            if (it != primitive_json.end() && it->isDouble()) {
-                compressed_primitive.accessorsToClean.insert(it->toInt());
-            }
-
-            it = primitive_json.find(GLTF2Import::KEY_ATTRIBUTES);
-            if (it != primitive_json.end() && it->isObject()) {
-                const auto attributes = it->toObject();
-                for (const auto &attr : attributes) {
-                    if (attr.isDouble())
-                        compressed_primitive.accessorsToClean.insert(attr.toInt());
-                }
-            }
-        }
-        compressed_primitive.primitiveJson = primitive_json;
-
-        return compressed_primitive;
-    }
-
-    void removeBufferViews(const std::set<int> &indicesToRemove)
-    {
-        // First compute the new indices of the buffer views
-        std::map<int, int> bufferViewIndex;
-        int currentOffset = 0;
-        for (int i = 0, n = m_bufferViews.size(); i < n; i++) {
-            if (indicesToRemove.count(i) != 0) {
-                currentOffset++;
-            }
-            bufferViewIndex[i] = i - currentOffset;
-        }
-
-        auto updateExistingIndex = [&](QJsonObject &obj, const QLatin1String &key) {
-            auto it = obj.find(key);
-            if (it != obj.end()) {
-                it.value() = bufferViewIndex.at(it.value().toInt());
-            }
-        };
-
-        // Fix them in the accessors
-        for (int i = 0; i < m_accessors.size(); i++) {
-            auto acc = m_accessors[i].toObject();
-
-            updateExistingIndex(acc, GLTF2Import::KEY_BUFFERVIEW);
-
-            {
-                auto it = acc.find(GLTF2Import::KEY_SPARSE);
-                if (it != acc.end()) {
-                    auto sparse = it->toObject();
-                    {
-                        auto indices = sparse.value(GLTF2Import::KEY_INDICES).toObject();
-                        updateExistingIndex(indices, GLTF2Import::KEY_BUFFERVIEW);
-                        sparse[GLTF2Import::KEY_INDICES] = std::move(indices);
-                    }
-                    {
-                        auto values = sparse.value(GLTF2Import::KEY_VALUES).toObject();
-                        updateExistingIndex(values, GLTF2Import::KEY_BUFFERVIEW);
-                        sparse[GLTF2Import::KEY_VALUES] = std::move(values);
-                    }
-                    *it = std::move(sparse);
-                }
-            }
-
-            m_accessors[i] = std::move(acc);
-        }
-
-        // Fix them in the meshes
-        for (int i = 0; i < m_meshes.size(); i++) {
-            auto mesh = m_meshes[i].toObject();
-            auto primitives = mesh[GLTF2Import::KEY_PRIMITIVES].toArray();
-            for (int p = 0; p < primitives.size(); p++) {
-                auto primitive = primitives[p].toObject();
-
-                auto ext_it = primitive.find(GLTF2Import::KEY_EXTENSIONS);
-                if (ext_it != primitive.end()) {
-                    auto ext = ext_it->toObject();
-
-                    auto draco_it = ext.find(GLTF2Import::KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION);
-                    if (draco_it != ext.end()) {
-                        auto draco = draco_it->toObject();
-                        updateExistingIndex(draco, GLTF2Import::KEY_BUFFERVIEW);
-                        *draco_it = std::move(draco);
-                    }
-
-                    *ext_it = std::move(ext);
-                }
-
-                primitives[p] = std::move(primitive);
-            }
-            mesh[GLTF2Import::KEY_PRIMITIVES] = std::move(primitives);
-            m_meshes[i] = std::move(mesh);
-        }
-
-        // Fix them in the images
-        for (int i = 0; i < m_images.size(); i++) {
-            auto img = m_images[i].toObject();
-            updateExistingIndex(img, GLTF2Import::KEY_BUFFERVIEW);
-            m_images[i] = std::move(img);
-        }
-
-        // Remove the buffer views
-        QJsonArray removedBufferViews;
-        // (note: this loop could be merged with the earlier one
-        // but this would be a bit less readable imho)
-        for (auto it = indicesToRemove.rbegin(); it != indicesToRemove.rend(); ++it) {
-            auto bv_it = m_bufferViews.begin() + (*it);
-
-            removedBufferViews.push_back(std::move(*bv_it));
-            m_bufferViews.erase(bv_it);
-        }
-
-        cleanupBuffers(removedBufferViews);
-    }
-
-    struct BufferParts {
-        int offset{};
-        int length{};
-        int stride{};
-        friend bool operator==(const BufferParts &lhs, const BufferParts &rhs)
-        {
-            return lhs.offset == rhs.offset;
-        }
-        friend bool operator<(const BufferParts &lhs, const BufferParts &rhs)
-        {
-            return lhs.offset < rhs.offset;
-        }
-    };
-
-    // Maps the new index of an offset in a buffer after removal of prior parts
-    static int mapBufferOffset(const std::set<BufferParts> &removed_parts, int offset)
-    {
-        const auto compare = [](const BufferParts &lhs, int rhs) { return lhs.offset < rhs; };
-        const auto end = std::lower_bound(
-                removed_parts.begin(), removed_parts.end(), offset, compare);
-
-        for (auto it = removed_parts.begin(); it != end; ++it) {
-            offset -= it->length;
-        }
-
-        return offset;
-    }
-
-    // Removes the unused data in buffers
-    void cleanupBuffers(const QJsonArray &removedBufferViews)
-    {
-        using namespace GLTF2Import;
-        std::map<int, std::set<BufferParts>> bufferParts;
-        // List and order all the parts of the buffers to remove
-        for (const QJsonValue &bv_value : removedBufferViews) {
-            auto bv = bv_value.toObject();
-            auto it = bv.find(GLTF2Import::KEY_BUFFER);
-            if (it != bv.end()) {
-                const int buffer_idx = it.value().toInt();
-                const auto buf = m_buffers[buffer_idx].toObject();
-                const auto uri = buf[GLTF2Import::KEY_URI].toString();
-                const bool is_embedded = Uri::kind(uri) == Uri::Kind::Data;
-
-                if (is_embedded || QFileInfo::exists(Uri::localFile(uri, m_basePath))) {
-                    BufferParts p;
-                    p.offset = bv[GLTF2Import::KEY_BYTEOFFSET].toInt();
-                    p.length = bv[GLTF2Import::KEY_BYTELENGTH].toInt();
-                    p.stride = bv[GLTF2Import::KEY_BYTESTRIDE].toInt();
-
-                    bufferParts[buffer_idx].insert(p);
-                } else {
-                    m_errors << QStringLiteral("File does not exist: %1").arg(uri);
-                }
-            }
-        }
-
-        // Remove the parts in the buffers
-        std::vector<int> buffersToRemove;
-
-        // TODO we should check that all buffer objects map to a unique file
-        // else this won't work at all
-        for (const auto &buffer : bufferParts) {
-            QJsonObject buf = m_buffers[buffer.first].toObject();
-
-            const auto uri = buf[GLTF2Import::KEY_URI].toString();
-            const bool is_embedded = Uri::kind(uri) == Uri::Kind::Data;
-
-            bool success = false;
-            auto data = Uri::fetchData(uri, m_basePath, success);
-            if (!success) {
-                if (is_embedded)
-                    m_errors << QStringLiteral("Could not read embedded buffer");
-                else
-                    m_errors << QStringLiteral("Could not read %1").arg(m_basePath.absoluteFilePath(uri));
-                continue;
-            }
-
-            int removed_length = 0;
-
-            // TODO handle overlapping bufferViews
-            // TODO handle strided buffers
-            for (auto it = buffer.second.rbegin(); it != buffer.second.rend(); ++it) {
-                data.remove(it->offset, it->length);
-                removed_length += it->length;
-            }
-
-            if (data.isEmpty()) {
-                // Actually we could precompute this case...
-                buffersToRemove.push_back(buffer.first);
-            } else {
-                if (!is_embedded) {
-                    QDir{}.mkpath(QFileInfo(m_destination, uri).absolutePath());
-                    QFile target_f(m_destination.filePath(uri));
-                    if (!target_f.open(QIODevice::WriteOnly)) {
-                        m_errors << QStringLiteral("Could not open %1 for writing").arg(target_f.fileName());
-                        continue;
-                    }
-                    const auto written = target_f.write(data);
-                    if (written != data.size()) {
-                        m_errors << QStringLiteral("Could not write buffer %1 entirely").arg(target_f.fileName());
-                        continue;
-                    }
-                } else {
-                    QByteArray output{ "data:application/octet-stream;base64," };
-                    output += data.toBase64();
-                    buf[GLTF2Import::KEY_URI] = QString::fromLatin1(output);
-                }
-
-                const auto len_it = buf.find(GLTF2Import::KEY_BYTELENGTH);
-                if (len_it != buf.end()) {
-                    (*len_it) = len_it->toInt() - removed_length;
-                }
-
-                m_buffers[buffer.first] = std::move(buf);
-            }
-        }
-
-        // Change the offsets in the bufferViews
-        for (auto bv_it = m_bufferViews.begin(); bv_it != m_bufferViews.end(); ++bv_it) {
-            auto bv = bv_it->toObject();
-            auto it = bv.find(GLTF2Import::KEY_BUFFER);
-            if (it != bv.end()) {
-                const int buffer_idx = it.value().toInt();
-
-                // Change the offset of the data in the buffer
-                auto offset_it = bv.find(GLTF2Import::KEY_BYTEOFFSET);
-                (*offset_it) = mapBufferOffset(bufferParts[buffer_idx], offset_it->toInt());
-
-                // Change the buffer index if there are removed buffers
-                int new_buffer_idx = buffer_idx;
-                for (int removed_buf : buffersToRemove) {
-                    if (removed_buf < buffer_idx)
-                        new_buffer_idx--;
-                    else
-                        break;
-                }
-                (*it) = new_buffer_idx;
-                (*bv_it) = std::move(bv);
-            }
-        }
-
-        // Remove unused buffers
-        for (int buffer : buffersToRemove) {
-            m_buffers.erase(m_buffers.begin() + buffer);
-        }
-
-        // TODO Do a final pass to check if there are any unreferenced buffers
-        // Or it could maybe be an additional "lint" pass not part of the draco one ?
-    }
-
-    // Add an extension if it is not already registered - this could be moved at a more generic place
-    // if further extensions are to be added
-    static void addExtension(QJsonObject &rootObject, const QString &where, const QString &extension)
-    {
-        auto extensions = rootObject[where].toArray();
-        auto ext_it = std::find_if(extensions.begin(), extensions.end(), [&](const QJsonValue &v) {
-            return v.toString() == extension;
-        });
-
-        if (ext_it == extensions.end()) {
-            extensions.push_back(extension);
-            rootObject[where] = std::move(extensions);
-        }
-    }
-
-    // Given an accessor array, remove their "bufferView": key, and return the corresponding set of
-    // bufferViews
-    static std::set<int> cleanAccessors(QJsonArray &accessors, const std::set<int> &indices)
-    {
-        std::set<int> bufferViews;
-        for (int accessor : indices) {
-            auto acc = accessors[accessor].toObject();
-            auto it = acc.find(GLTF2Import::KEY_BUFFERVIEW);
-            if (it != acc.end()) {
-                bufferViews.insert(it.value().toInt());
-                acc.erase(it);
-
-                acc.remove(GLTF2Import::KEY_BYTEOFFSET);
-            }
-            accessors[accessor] = std::move(acc);
-        }
-        return bufferViews;
-    }
-};
-#endif
-
-} // namespace
+    return m_embedding;
+}
+
+void GLTF2ExportConfiguration::setEmbedding(Embed e)
+{
+    m_embedding = e;
+}
 
 GLTF2Exporter::GLTF2Exporter(QObject *parent)
     : QObject(parent)
@@ -670,7 +163,7 @@ void GLTF2Exporter::setContextFromImporter(GLTF2Importer *importer)
 QStringList GLTF2Exporter::overwritableFiles(const QDir &target) const
 {
     QStringList files;
-    for (const auto& file : m_context->localFiles()) {
+    for (const auto &file : m_context->localFiles()) {
         auto filePath = GLTF2Import::Uri::localFile(file, target);
         if (!filePath.startsWith(QStringLiteral(":/"))) {
             if (QFileInfo::exists(filePath))
@@ -686,7 +179,7 @@ auto GLTF2Exporter::saveInFolder(
 {
     m_errors.clear();
     if (!m_context) {
-        m_errors << QLatin1String("Tried to save GLTF without a context");
+        m_errors << QStringLiteral("Tried to save GLTF without a context");
         return {};
     }
 
@@ -696,17 +189,22 @@ auto GLTF2Exporter::saveInFolder(
     }
 
     QJsonObject rootObject = m_context->json().object();
-    QString compressedBuffer;
+    QString compressedBufferFilename;
     if (rootObject.isEmpty()) {
         m_errors << QStringLiteral("Nothing to save");
         return {};
     }
 
+    CopyExportPass copy_pass(source, target);
+
 #if defined(KUESA_DRACO_COMPRESSION)
     if (m_conf.meshCompressionEnabled()) {
-        GLTF2DracoCompressor compressor(source, target, rootObject, m_conf, *m_context);
-        rootObject = compressor.compress();
-        compressedBuffer = compressor.compressedBufferFilename();
+        DracoExportPass pass(m_context->filename(), source, target, rootObject, m_conf, *m_context);
+        rootObject = pass.compress();
+        compressedBufferFilename = pass.compressedBufferFilename();
+        if (!compressedBufferFilename.isEmpty()) {
+            copy_pass.addGeneratedFiles({ compressedBufferFilename });
+        }
         if (rootObject.empty()) {
             m_errors << QStringLiteral("Draco compression failed");
             return {};
@@ -714,57 +212,47 @@ auto GLTF2Exporter::saveInFolder(
     }
 #endif
 
-    if (source != target) {
-        // Copy buffers
-        auto buffers_it = rootObject.find(GLTF2Import::KEY_BUFFERS);
-        if (buffers_it != rootObject.end()) {
-            copyURIs(source, target, buffers_it->toArray());
-        };
+    switch (m_conf.embedding()) {
+    case GLTF2ExportConfiguration::Embed::Keep: {
+        copy_pass.copyURIs(rootObject, GLTF2Import::KEY_BUFFERS);
+        copy_pass.copyURIs(rootObject, GLTF2Import::KEY_IMAGES);
+        if (!copy_pass.errors().empty())
+            m_errors << copy_pass.errors();
+        break;
+    }
+    case GLTF2ExportConfiguration::Embed::None: {
+        // In this case we do both copy and extraction
+        {
+            SeparateExportPass pass(m_context->filename(), target);
+            pass.separateURIs(rootObject);
+            if (!pass.errors().empty())
+                m_errors << pass.errors();
 
-        // Copy images
-        auto images_it = rootObject.find(GLTF2Import::KEY_IMAGES);
-        if (images_it != rootObject.end()) {
-            copyURIs(source, target, images_it->toArray());
+            copy_pass.addGeneratedFiles(pass.generatedFiles());
         }
+
+        {
+            copy_pass.copyURIs(rootObject, GLTF2Import::KEY_BUFFERS);
+            copy_pass.copyURIs(rootObject, GLTF2Import::KEY_IMAGES);
+            if (!copy_pass.errors().empty())
+                m_errors << copy_pass.errors();
+        }
+        break;
+    }
+    case GLTF2ExportConfiguration::Embed::All: {
+        EmbedExportPass pass(source);
+        pass.embedURIsInArray(rootObject, GLTF2Import::KEY_BUFFERS);
+        pass.embedURIsInArray(rootObject, GLTF2Import::KEY_IMAGES);
+        if (!pass.errors().empty())
+            m_errors << pass.errors();
+        break;
+    }
     }
 
     Export e;
     e.m_json = std::move(rootObject);
-    e.m_compressedBufferFilename = std::move(compressedBuffer);
+    e.m_compressedBufferFilename = std::move(compressedBufferFilename);
     return e;
-}
-
-// Copies all the files referenced in an array of GLTF objects
-void GLTF2Exporter::copyURIs(const QDir &source, const QDir &target, const QJsonArray &array)
-{
-    using namespace GLTF2Import;
-    for (const auto &val : array) {
-        const auto &buffer = val.toObject();
-        auto uri_it = buffer.find(GLTF2Import::KEY_URI);
-        if (uri_it == buffer.end())
-            return;
-
-        const auto uri = uri_it->toString();
-        if (Uri::kind(uri) != Uri::Kind::Path)
-            return;
-
-        QFile srcFile(Uri::localFile(uri_it->toString(), source));
-        const QFileInfo destFile(target, uri_it->toString());
-
-        if (!destFile.exists()) {
-            if (srcFile.exists()) {
-                // Copy files from the source to the target directory
-                QDir{}.mkpath(destFile.absolutePath());
-
-                bool ok = srcFile.copy(target.absoluteFilePath(uri_it->toString()));
-                if (!ok) {
-                    m_errors << QStringLiteral("Unable to copy %1").arg(uri_it->toString());
-                }
-            } else {
-                m_errors << QStringLiteral("Tried to copy missing file %1").arg(uri_it->toString());
-            }
-        }
-    }
 }
 
 void GLTF2Exporter::setScene(SceneEntity *scene)

--- a/src/core/gltf2exporter/gltf2exporter_p.h
+++ b/src/core/gltf2exporter/gltf2exporter_p.h
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
@@ -77,9 +77,19 @@ public:
     void setMeshCompressionEnabled(bool enabled);
     bool meshCompressionEnabled() const;
 
+    enum Embed {
+        Keep, //! Keep embedded data as-is.
+        None, //! Move all embedded data in outside files.
+        All //! Embed all the data in the glTF file.
+    };
+
+    void setEmbedding(Embed);
+    Embed embedding() const;
+
 private:
     int m_encodingSpeed{};
     int m_decodingSpeed{};
+    Embed m_embedding{ Embed::Keep };
     bool m_meshCompression{};
     QMap<MeshAttribute, int> m_quantization;
 };
@@ -117,24 +127,24 @@ public:
     QStringList overwritableFiles(const QDir &target) const;
 
 Q_SIGNALS:
-    void sceneChanged(SceneEntity *scene);
+    void sceneChanged(Kuesa::SceneEntity *scene);
 
 public Q_SLOTS:
-    void setScene(SceneEntity *scene);
+    void setScene(Kuesa::SceneEntity *scene);
 
     Export saveInFolder(
             const QDir &sourceFolder,
             const QDir &targetFolder);
 
 private:
-    void copyURIs(const QDir &source, const QDir &target, const QJsonArray &array);
-
     GLTF2Import::GLTF2Context *m_context;
     SceneEntity *m_scene;
 
     GLTF2ExportConfiguration m_conf;
     QStringList m_errors;
 };
+
+QString generateUniqueFilename(const QDir &dir, QString filename);
 } // namespace Kuesa
 QT_END_NAMESPACE
 

--- a/src/core/gltf2exporter/gltf2utils_p.cpp
+++ b/src/core/gltf2exporter/gltf2utils_p.cpp
@@ -1,5 +1,5 @@
 /*
-    draco_prefix_p.h
+    gltf2utils_p.cpp
 
     This file is part of Kuesa.
 
@@ -26,26 +26,41 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef KUESA_DRACO_PREFIX_P_H
-#define KUESA_DRACO_PREFIX_P_H
+#include "gltf2utils_p.h"
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QLatin1String>
+#include <algorithm>
 
-//
-//  W A R N I N G
-//  -------------
-//
-// This file is not part of the Kuesa API.  It exists for the convenience
-// of other Kuesa classes.  This header file may change from version to
-// version without notice, or even be removed.
-//
-// We mean it.
-//
+QT_BEGIN_NAMESPACE
+namespace Kuesa {
+/*!
+ * Add an extension to a glTF object if it is not already registered
+ */
+void addExtension(QJsonObject &object, const QString &where, const QString &extension)
+{
+    auto extensions = object[where].toArray();
+    auto ext_it = std::find_if(extensions.begin(), extensions.end(), [&](const QJsonValue &v) {
+        return v.toString() == extension;
+    });
 
-#if defined(_WIN32)
+    if (ext_it == extensions.end()) {
+        extensions.push_back(extension);
+        object[where] = std::move(extensions);
+    }
+}
 
-#if defined(ERROR)
-#undef ERROR
-#endif
+/*!
+ * Replace a Json array in an object, or remove it from the object if the array is empty.
+ */
+void replaceJsonArray(QJsonObject &object, QLatin1String k, QJsonArray &arr)
+{
+    auto it = object.find(k);
+    if (it != object.end() && arr.empty())
+        object.erase(it);
+    else if (!arr.empty())
+        *it = std::move(arr);
+}
 
-#endif
-
-#endif // KUESA_DRACO_PREFIX_P_H
+} // namespace Kuesa
+QT_END_NAMESPACE

--- a/src/core/gltf2exporter/gltf2utils_p.h
+++ b/src/core/gltf2exporter/gltf2utils_p.h
@@ -1,5 +1,5 @@
 /*
-    draco_prefix_p.h
+    gltf2utils_p.h
 
     This file is part of Kuesa.
 
@@ -26,26 +26,30 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef KUESA_DRACO_PREFIX_P_H
-#define KUESA_DRACO_PREFIX_P_H
+#ifndef KUESA_GLTF2EXPORTER_GLTF2UTILS_P_H
+#define KUESA_GLTF2EXPORTER_GLTF2UTILS_P_H
 
 //
-//  W A R N I N G
-//  -------------
+//  NOTICE
+//  ------
 //
-// This file is not part of the Kuesa API.  It exists for the convenience
-// of other Kuesa classes.  This header file may change from version to
-// version without notice, or even be removed.
+// We mean it: this file is not part of the public API and could be
+// modified without notice
 //
-// We mean it.
-//
+#include <QtGlobal>
 
-#if defined(_WIN32)
+QT_BEGIN_NAMESPACE
 
-#if defined(ERROR)
-#undef ERROR
-#endif
+class QJsonObject;
+class QJsonArray;
+class QLatin1String;
+class QString;
 
-#endif
+namespace Kuesa {
 
-#endif // KUESA_DRACO_PREFIX_P_H
+void addExtension(QJsonObject &rootObject, const QString &where, const QString &extension);
+
+void replaceJsonArray(QJsonObject &m_root, QLatin1String k, QJsonArray &arr);
+} // namespace Kuesa
+QT_END_NAMESPACE
+#endif // KUESA_GLTF2EXPORTER_GLTF2UTILS_P_H

--- a/src/core/gltf2exporter/separateexportpass_p.cpp
+++ b/src/core/gltf2exporter/separateexportpass_p.cpp
@@ -1,0 +1,172 @@
+/*
+    separateexportpass_cpp.h
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "separateexportpass_p.h"
+#include "gltf2keys_p.h"
+#include "gltf2exporter_p.h"
+#include "gltf2uri_p.h"
+#include <QJsonArray>
+#include <QDebug>
+#include <QMimeDatabase>
+QT_BEGIN_NAMESPACE
+namespace Kuesa {
+
+namespace {
+
+QString bufferNamer(const QString &basename, const QJsonObject &obj, const QByteArray & /*data*/, int count)
+{
+    QString name;
+
+    const auto name_it = obj.constFind(GLTF2Import::KEY_NAME);
+    if (name_it != obj.constEnd()) {
+        name = name_it->toString();
+    } else {
+        name = basename;
+    }
+
+    if (name.isEmpty())
+        name = QStringLiteral("buffer");
+
+    return QStringLiteral("%1-%2.bin").arg(name).arg(count);
+}
+
+QString imageNamer(const QString &basename, const QJsonObject &obj, const QByteArray &data, int count)
+{
+    QString name;
+    const auto name_it = obj.constFind(GLTF2Import::KEY_NAME);
+    if (name_it != obj.constEnd()) {
+        name = name_it->toString();
+    } else {
+        name = basename;
+    }
+
+    if (name.isEmpty())
+        name = QStringLiteral("image");
+
+    QString suffix;
+    const auto mime_it = obj.constFind(GLTF2Import::KEY_MIMETYPE);
+    if (mime_it != obj.constEnd()) {
+        const auto mime = mime_it->toString();
+        if (mime == QLatin1Literal("image/jpeg")) {
+            suffix = QStringLiteral("jpeg");
+        } else if (mime == QLatin1Literal("image/png")) {
+            suffix = QStringLiteral("png");
+        }
+    }
+
+    if (suffix.isEmpty()) {
+        static const QMimeDatabase db;
+        const auto mimeType = db.mimeTypeForData(data);
+        suffix = mimeType.preferredSuffix();
+    }
+
+    return QStringLiteral("%1-%2.%3").arg(name).arg(count).arg(suffix);
+}
+
+} // namespace
+
+/*!
+ * \class SeparateExportPass
+ * \brief glTF export pass that takes all the base64-encoded embedded buffers and saves them in files.
+ */
+SeparateExportPass::SeparateExportPass(const QString &filename, const QDir &destination)
+    : m_basename(QFileInfo(filename).baseName())
+    , m_destination(destination)
+{
+}
+
+const QStringList &SeparateExportPass::errors() const
+{
+    return m_errors;
+}
+
+const QStringList &SeparateExportPass::generatedFiles() const
+{
+    return m_generated;
+}
+
+void SeparateExportPass::separateURIs(QJsonObject &root)
+{
+    separateURIsInArray(root, GLTF2Import::KEY_BUFFERS, bufferNamer);
+    m_extractedCount = 0;
+    separateURIsInArray(root, GLTF2Import::KEY_IMAGES, imageNamer);
+}
+
+void SeparateExportPass::separateURIsInArray(QJsonObject &root, QLatin1String key, NamingFunction namer)
+{
+    auto array_it = root.find(key);
+    if (array_it == root.end())
+        return;
+
+    auto array = array_it->toArray();
+    for (QJsonValueRef val_v : array) {
+        auto obj = val_v.toObject();
+        if (separateEncodedUri(obj, namer)) {
+            val_v = obj;
+        }
+    }
+    *array_it = array;
+}
+
+bool SeparateExportPass::separateEncodedUri(QJsonObject &object, NamingFunction namer)
+{
+    using namespace GLTF2Import;
+
+    auto uri_it = object.find(GLTF2Import::KEY_URI);
+    if (uri_it == object.end())
+        return false;
+
+    const auto &uri = uri_it->toString();
+    if (Uri::kind(uri) != Uri::Kind::Data)
+        return false;
+
+    // Decode the data
+    const auto data = Uri::parseEmbeddedData(uri);
+
+    // Get a proper filename
+    const auto basename = namer(m_basename, object, data, m_extractedCount);
+    const auto file = generateUniqueFilename(m_destination, basename);
+    const auto filepath = m_destination.filePath(file);
+
+    // Write the resource file
+    QFile resource(filepath);
+    if (!resource.open(QIODevice::WriteOnly)) {
+        m_errors << QStringLiteral("Cannot create: %1").arg(uri);
+        return false;
+    }
+    resource.write(data);
+
+    *uri_it = file;
+
+    m_generated.push_back(file);
+    ++m_extractedCount;
+    return true;
+}
+
+} // namespace Kuesa
+QT_END_NAMESPACE

--- a/src/core/gltf2exporter/separateexportpass_p.h
+++ b/src/core/gltf2exporter/separateexportpass_p.h
@@ -1,5 +1,5 @@
 /*
-    draco_prefix_p.h
+    separateexportpass_p.h
 
     This file is part of Kuesa.
 
@@ -26,26 +26,45 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef KUESA_DRACO_PREFIX_P_H
-#define KUESA_DRACO_PREFIX_P_H
+#ifndef KUESA_GLTF2EXPORTER_SEPARATEEXPORTPASS_P_H
+#define KUESA_GLTF2EXPORTER_SEPARATEEXPORTPASS_P_H
 
 //
-//  W A R N I N G
-//  -------------
+//  NOTICE
+//  ------
 //
-// This file is not part of the Kuesa API.  It exists for the convenience
-// of other Kuesa classes.  This header file may change from version to
-// version without notice, or even be removed.
-//
-// We mean it.
+// We mean it: this file is not part of the public API and could be
+// modified without notice
 //
 
-#if defined(_WIN32)
+#include <QDir>
+#include <QStringList>
+#include <QJsonObject>
 
-#if defined(ERROR)
-#undef ERROR
-#endif
+QT_BEGIN_NAMESPACE
+namespace Kuesa {
+class SeparateExportPass
+{
+public:
+    SeparateExportPass(
+            const QString &basename,
+            const QDir &destination);
 
-#endif
+    const QStringList &errors() const;
+    const QStringList &generatedFiles() const;
+    void separateURIs(QJsonObject &root);
 
-#endif // KUESA_DRACO_PREFIX_P_H
+private:
+    using NamingFunction = QString (*)(const QString &, const QJsonObject &, const QByteArray &, int);
+    void separateURIsInArray(QJsonObject &root, QLatin1String key, NamingFunction);
+    bool separateEncodedUri(QJsonObject &object, NamingFunction);
+
+    int m_extractedCount = 0;
+    QStringList m_errors;
+    QStringList m_generated;
+    QString m_basename;
+    QDir m_destination;
+};
+} // namespace Kuesa
+QT_END_NAMESPACE
+#endif // KUESA_GLTF2EXPORTER_SEPARATEEXPORTPASS_P_H

--- a/src/core/gltf2importer/gltf2context.cpp
+++ b/src/core/gltf2importer/gltf2context.cpp
@@ -340,6 +340,16 @@ void GLTF2Context::setRequiredExtensions(const QStringList &requiredExtensions)
     m_requiredExtensions = requiredExtensions;
 }
 
+const QString &GLTF2Context::filename() const
+{
+    return m_filename;
+}
+
+void GLTF2Context::setFilename(const QString &name)
+{
+    m_filename = name;
+}
+
 const QJsonDocument &GLTF2Context::json() const
 {
     return m_json;

--- a/src/core/gltf2importer/gltf2context_p.h
+++ b/src/core/gltf2importer/gltf2context_p.h
@@ -144,6 +144,9 @@ public:
     QStringList requiredExtensions() const;
     void setRequiredExtensions(const QStringList &requiredExtensions);
 
+    const QString &filename() const;
+    void setFilename(const QString &);
+
     const QJsonDocument &json() const;
     void setJson(const QJsonDocument &doc);
 
@@ -167,6 +170,7 @@ private:
     QVector<Skin> m_skins;
     QStringList m_usedExtensions;
     QStringList m_requiredExtensions;
+    QString m_filename;
     QJsonDocument m_json;
     QStringList m_localFiles;
 };

--- a/src/core/gltf2importer/gltf2keys_p.h
+++ b/src/core/gltf2importer/gltf2keys_p.h
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
@@ -77,6 +77,7 @@ const QLatin1String KEY_BYTESTRIDE = QLatin1String("byteStride");
 const QLatin1String KEY_INDICES = QLatin1String("indices");
 const QLatin1String KEY_VALUES = QLatin1String("values");
 const QLatin1String KEY_SPARSE = QLatin1String("sparse");
+const QLatin1String KEY_MIMETYPE = QLatin1String("mimeType");
 #if defined(KUESA_DRACO_COMPRESSION)
 const QLatin1String KEY_KHR_DRACO_MESH_COMPRESSION_EXTENSION = QLatin1String("KHR_draco_mesh_compression");
 #endif

--- a/src/core/gltf2importer/gltf2parser.cpp
+++ b/src/core/gltf2importer/gltf2parser.cpp
@@ -149,7 +149,7 @@ Qt3DCore::QEntity *GLTF2Parser::parse(const QString &filePath)
 
     QFileInfo finfo(filePath);
     const QByteArray jsonData = f.readAll();
-    return parse(jsonData, finfo.absolutePath());
+    return parse(jsonData, finfo.absolutePath(), finfo.fileName());
 }
 
 template<class T>
@@ -282,7 +282,7 @@ QVector<KeyParserFuncPair> GLTF2Parser::prepareParsers()
     };
 }
 
-Qt3DCore::QEntity *GLTF2Parser::parse(const QByteArray &jsonData, const QString &basePath)
+Qt3DCore::QEntity *GLTF2Parser::parse(const QByteArray &jsonData, const QString &basePath, const QString &filename)
 {
     QJsonDocument jsonDocument = QJsonDocument::fromJson(jsonData);
     if (jsonDocument.isNull() || !jsonDocument.isObject()) {
@@ -292,6 +292,7 @@ Qt3DCore::QEntity *GLTF2Parser::parse(const QByteArray &jsonData, const QString 
 
     Q_ASSERT(m_context);
     m_context->setJson(jsonDocument);
+    m_context->setFilename(filename);
 
     m_animators.clear();
     m_treeNodes.clear();

--- a/src/core/gltf2importer/gltf2parser_p.h
+++ b/src/core/gltf2importer/gltf2parser_p.h
@@ -82,7 +82,7 @@ public:
 
     virtual QVector<KeyParserFuncPair> prepareParsers();
     Qt3DCore::QEntity *parse(const QString &filePath);
-    Qt3DCore::QEntity *parse(const QByteArray &jsonData, const QString &basePath);
+    Qt3DCore::QEntity *parse(const QByteArray &jsonData, const QString &basePath, const QString &filename = {});
 
     void setContext(GLTF2Context *);
     const GLTF2Context *context() const;

--- a/src/core/gltf2importer/gltf2uri.cpp
+++ b/src/core/gltf2importer/gltf2uri.cpp
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
@@ -44,6 +44,9 @@ Kind kind(const QString &uri)
             : Kind::Path;
 }
 
+/*!
+ * Create a QUrl containing the absolute path to a file referenced in a glTF uri.
+ */
 QUrl absoluteUrl(const QString &uri, const QDir &basePath)
 {
     QUrl url;
@@ -65,6 +68,9 @@ QUrl absoluteUrl(const QString &uri, const QDir &basePath)
     return url;
 }
 
+/*!
+ * Create a QString containing the absolute path to a file referenced in a glTF uri.
+ */
 QString localFile(const QString &uri, const QDir &basePath)
 {
     QString path;
@@ -82,6 +88,9 @@ QString localFile(const QString &uri, const QDir &basePath)
     return path;
 }
 
+/*!
+ * Converts a glTF data uri into a binary data buffer.
+ */
 QByteArray parseEmbeddedData(const QString &uri)
 {
     QByteArray data = uri.toLatin1();
@@ -103,6 +112,17 @@ QByteArray parseEmbeddedData(const QString &uri)
     return QByteArray::fromBase64(data.remove(0, separatorPos + 1));
 }
 
+/*!
+ * Converts binary data into a data uri embeddable in a glTF object.
+ */
+QByteArray toBase64Uri(const QByteArray &arr)
+{
+    return "data:application/octet-stream;base64," + arr.toBase64();
+}
+
+/*!
+ * Get the binary data buffer referenced by a glTF uri.
+ */
 QByteArray fetchData(const QString &uri, const QDir &basePath, bool &success)
 {
     switch (kind(uri)) {

--- a/src/core/gltf2importer/gltf2uri_p.h
+++ b/src/core/gltf2importer/gltf2uri_p.h
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
@@ -65,6 +65,9 @@ QString localFile(const QString &uri, const QDir &basePath);
 
 KUESA_PRIVATE_EXPORT
 QByteArray parseEmbeddedData(const QString &uri);
+
+KUESA_PRIVATE_EXPORT
+QByteArray toBase64Uri(const QByteArray &arr);
 
 KUESA_PRIVATE_EXPORT
 QByteArray fetchData(const QString &uri, const QDir &basePath, bool &success);

--- a/src/core/gltf2importer/meshparser_utils.cpp
+++ b/src/core/gltf2importer/meshparser_utils.cpp
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Juan Casafranca <juan.casafranca@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/src/core/gltf2importer/meshparser_utils_p.h
+++ b/src/core/gltf2importer/meshparser_utils_p.h
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Juan Casafranca <juan.casafranca@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/src/core/kuesa_global_p.h
+++ b/src/core/kuesa_global_p.h
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/tests/auto/assets/mixed_datauris.gltf
+++ b/tests/auto/assets/mixed_datauris.gltf
@@ -1,0 +1,24 @@
+{
+"buffers": [
+    {
+        "byteLength": 5,
+        "name": "buffer_data",
+        "uri": "data:application/octet-stream;base64,S3Vlc2E="
+    },
+    {
+        "byteLength": 5,
+        "name": "buffer_file",
+        "uri": "uri_qrc_test.bin"
+    }
+],
+"images": [
+    {
+        "name": "image_data",
+        "uri": "data:application/octet-stream;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNcrd3/HwAFVAJmXFyG2AAAAABJRU5ErkJggg=="
+    },
+    {
+        "name": "image_file",
+        "uri": "GeneratedAssets/Texture_Sampler/Textures/BaseColor_Plane.png"
+    }
+]
+}

--- a/tests/auto/gltfexporter/gltfexporter.pro
+++ b/tests/auto/gltfexporter/gltfexporter.pro
@@ -2,7 +2,7 @@
 #
 # This file is part of Kuesa.
 #
-# Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 # Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 #
 # Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/tests/auto/uri/tst_uri.cpp
+++ b/tests/auto/uri/tst_uri.cpp
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/tests/auto/uri/uri.pro
+++ b/tests/auto/uri/uri.pro
@@ -2,7 +2,7 @@
 #
 # This file is part of Kuesa.
 #
-# Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 # Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 #
 # Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/tools/assetpipelineeditor/exportdialog.cpp
+++ b/tools/assetpipelineeditor/exportdialog.cpp
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/tools/assetpipelineeditor/exportdialog.cpp
+++ b/tools/assetpipelineeditor/exportdialog.cpp
@@ -129,6 +129,13 @@ void ExportDialog::onSave()
         conf.setAttributeQuantizationLevel(ExportConf::TextureCoordinate, mapSlider(ui->textureQuantizationSlider));
         conf.setAttributeQuantizationLevel(ExportConf::Generic, mapSlider(ui->genericQuantizationSlider));
 
+        if (ui->embedKeep->isChecked())
+            conf.setEmbedding(ExportConf::Embed::Keep);
+        else if (ui->embedAll->isChecked())
+            conf.setEmbedding(ExportConf::Embed::All);
+        else if (ui->embedNone->isChecked())
+            conf.setEmbedding(ExportConf::Embed::None);
+
         m_exporter.setConfiguration(conf);
     }
 

--- a/tools/assetpipelineeditor/exportdialog.h
+++ b/tools/assetpipelineeditor/exportdialog.h
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/tools/assetpipelineeditor/exportdialog.ui
+++ b/tools/assetpipelineeditor/exportdialog.ui
@@ -14,20 +14,6 @@
    <string>Export</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Destination:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="destination"/>
-     </item>
-    </layout>
-   </item>
    <item row="0" column="1">
     <widget class="QLabel" name="sourceLabel">
      <property name="sizePolicy">
@@ -41,32 +27,13 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QPlainTextEdit" name="errorLog">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>100</height>
-      </size>
-     </property>
-     <property name="baseSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="2" rowspan="4">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Save|QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Save</set>
      </property>
     </widget>
    </item>
@@ -404,6 +371,72 @@
        <widget class="QLabel" name="emptyRow">
         <property name="text">
          <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Destination:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="destination"/>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="1">
+    <widget class="QPlainTextEdit" name="errorLog">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Asset embedding</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="embedKeep">
+        <property name="text">
+         <string>Keep as-is</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="embedAll">
+        <property name="text">
+         <string>Embed all assets in the glTF file</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QRadioButton" name="embedNone">
+        <property name="text">
+         <string>Save all assets in separate files</string>
         </property>
        </widget>
       </item>

--- a/tools/assetprocessor/assetprocessor.pro
+++ b/tools/assetprocessor/assetprocessor.pro
@@ -2,7 +2,7 @@
 #
 # This file is part of Kuesa.
 #
-# Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+# Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
 # Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 #
 # Licensees holding valid proprietary KDAB Kuesa licenses may use this file in

--- a/tools/assetprocessor/assetprocessor.pro
+++ b/tools/assetprocessor/assetprocessor.pro
@@ -25,6 +25,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 TEMPLATE = app
+CONFIG += console
+CONFIG -= app_bundle
 
 QT -= gui
 QT += kuesa kuesa-private

--- a/tools/assetprocessor/main.cpp
+++ b/tools/assetprocessor/main.cpp
@@ -35,6 +35,37 @@
 #include <QCommandLineParser>
 #include <QElapsedTimer>
 
+/*!
+    \page assetprocessor.html
+    \title Kuesa Asset Processor (assetprocessor)
+    \keyword assetprocessor
+
+    The \c assetprocessor tool is used to perform transformations of glTF files.
+
+    Usage:
+    \c{./assetcompressor -i my_file.gltf -o /path/to/new/folder -q 8}
+
+    assetprocessor accepts the following command line options:
+
+    \table
+    \header \li Option         \li Argument \li Description
+
+    \row \li \c{-i, --input} \li \c{file} \li glTF \c{file} to process.
+    \row \li \c{-o, --output} \li \c{folder} \li Output folder.
+    \row \li \c{-q, --quantization} \li \c{level} \li Mesh compression quantization. Uses the Draco mesh compression method.
+    \row \li \c{-e, --embed} \li \li Embed assets as base64 in the glTF file.
+    \row \li \c{-s, --separate} \li \li Separate embedded assets.
+    \row \li \c{-f, --force} \li \li Force overwriting of existing files.
+    \row \li \c{--stats} \li \li Compute and show size statistics.
+    \row \li \c{--version} \li \li Display version information.
+    \row \li \c{--help} \li \li Display usage information.
+
+    \endtable
+
+    If neither of \c{--embed} or \c{--separate} is specified, the assets will be kept
+    as they are.
+*/
+
 int main(int argc, char *argv[])
 {
     using namespace Kuesa;
@@ -51,20 +82,24 @@ int main(int argc, char *argv[])
     cmdline.addVersionOption();
     cmdline.setApplicationDescription(
             QObject::tr(
-                    "\nThis tool re-exports glTF 2.0 files with meshes compressed with the Draco algorithm.\n"
+                    "\nThis tool processes and transforms glTF 2.0 files.\n"
                     "Example : ./assetcompressor -i my_file.gltf -o /path/to/new/folder -q 8"));
 
-    QCommandLineOption inputOption({ "i", "input" }, QObject::tr("glTF2 <file> to compress."), QObject::tr("file"), QString());
+    QCommandLineOption inputOption({ "i", "input" }, QObject::tr("glTF2 <file> to process."), QObject::tr("file"), QString());
     QCommandLineOption outputOption({ "o", "output" }, QObject::tr("Output <directory>."), QObject::tr("directory"), QString());
-    QCommandLineOption ratioOption({ "q", "quantization" }, QObject::tr("Compression quantization, between 1 (more compressed) and 16 (less compressed)."), QObject::tr("value"), "7");
+    QCommandLineOption ratioOption({ "q", "quantization" }, QObject::tr("Mesh compression quantization, between 1 (more compressed) and 16 (less compressed)."), QObject::tr("value"));
+    QCommandLineOption embedOption({ "e", "embed" }, QObject::tr("Embed assets in base64."));
+    QCommandLineOption extractOption({ "s", "separate" }, QObject::tr("Separate embedded assets."));
     QCommandLineOption forceOption({ "f", "force" }, QObject::tr("Force overwriting existing files."));
+    QCommandLineOption statsOption("stats", QObject::tr("Compute and show size statistics."));
 
-    cmdline.addOptions({ inputOption, outputOption, ratioOption, forceOption });
+    cmdline.addOptions({ inputOption, outputOption, ratioOption, embedOption, extractOption, forceOption, statsOption });
 
     cmdline.process(app);
 
     const auto asset = cmdline.value(inputOption);
     const QFileInfo assetFileInfo(asset);
+    const auto sourceDir = assetFileInfo.dir();
     if (!cmdline.isSet(inputOption) || asset.isEmpty() || !assetFileInfo.exists()) {
         qCritical("Invalid input file.\n%s", cmdline.helpText().toLatin1().constData());
         return 1;
@@ -76,13 +111,22 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    const bool hasRatio = cmdline.isSet(ratioOption);
     const int ratio = cmdline.value(ratioOption).toInt();
-    if (ratio < 1 || ratio > 16) {
+    if (hasRatio && (ratio < 1 || ratio > 16)) {
         qCritical("Invalid compression ratio.\n%s", cmdline.helpText().toLatin1().constData());
         return 1;
     }
 
     const bool force = cmdline.isSet(forceOption);
+    const bool embed = cmdline.isSet(embedOption);
+    const bool extract = cmdline.isSet(extractOption);
+    if (embed && extract) {
+        qCritical("Cannot specify both --embed and --extract.\n%s", cmdline.helpText().toLatin1().constData());
+        return 1;
+    }
+
+    const bool stats = cmdline.isSet(statsOption);
 
     const QDir targetDir = outputDirArg;
     if (!targetDir.exists()) {
@@ -99,27 +143,51 @@ int main(int argc, char *argv[])
     GLTF2Parser parser(&scene);
     parser.setContext(&ctx);
 
+    QElapsedTimer timer;
+    qint64 sourceParseTime = 0;
+    qint64 processedParseTime = 0;
+
+    timer.start();
     const auto res = parser.parse(asset);
+    sourceParseTime = timer.elapsed();
+
     if (!res) {
         qCritical("Could not parse glTF2 file.");
         return 1;
     }
 
+    // Compute total input size
+    qint64 sourceSize = 0;
+    qint64 processedSize = 0;
+    if (stats) {
+        for (const auto &file : ctx.localFiles()) {
+            sourceSize += QFileInfo(sourceDir.filePath(file)).size();
+        }
+        sourceSize += assetFileInfo.size();
+    }
+
     // Compression
     GLTF2ExportConfiguration configuration;
-    configuration.setMeshCompressionEnabled(true);
-    configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Position, ratio);
-    configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Normal, ratio);
-    configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Color, ratio);
-    configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::TextureCoordinate, ratio);
-    configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Generic, ratio);
+    if (hasRatio) {
+        configuration.setMeshCompressionEnabled(true);
+        configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Position, ratio);
+        configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Normal, ratio);
+        configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Color, ratio);
+        configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::TextureCoordinate, ratio);
+        configuration.setAttributeQuantizationLevel(GLTF2ExportConfiguration::Generic, ratio);
+    }
+
+    if (embed)
+        configuration.setEmbedding(GLTF2ExportConfiguration::Embed::All);
+    else if (extract)
+        configuration.setEmbedding(GLTF2ExportConfiguration::Embed::None);
+    else
+        configuration.setEmbedding(GLTF2ExportConfiguration::Embed::Keep);
 
     GLTF2Exporter exporter;
     exporter.setContext(&ctx);
     exporter.setScene(&scene);
     exporter.setConfiguration(configuration);
-
-    const auto sourceDir = assetFileInfo.dir();
 
     // Check that we won't accidentally overwrite something
     auto overwriteable = exporter.overwritableFiles(targetDir);
@@ -127,15 +195,12 @@ int main(int argc, char *argv[])
         qCritical("Use --force if you want to overwrite the following files:\n%s\n", overwriteable.join("\n").toLatin1().constData());
     }
 
-    // Meaasure the actual export step duration
-    QElapsedTimer timer;
-    timer.start();
+    // Measure the actual export step duration
+    timer.restart();
+    const auto newAsset = exporter.saveInFolder(sourceDir, targetDir);
+    const auto exportTime = timer.elapsed();
 
-    const auto new_asset = exporter.saveInFolder(sourceDir, targetDir);
-
-    const auto time_taken = timer.nsecsElapsed();
-
-    if (!new_asset.success()) {
+    if (!newAsset.success()) {
         QTextStream errors;
         const auto &reporterErrors = exporter.errors();
         for (const auto &err : reporterErrors)
@@ -145,28 +210,52 @@ int main(int argc, char *argv[])
     }
 
     // Write down the new glTF file
-    {
-        const auto gltfFilename = assetFileInfo.baseName();
-        const auto gltfPath = QStringLiteral("%1/%2.gltf").arg(targetDir.absolutePath(), gltfFilename);
+    const auto newAssetJson = QJsonDocument{ newAsset.json() }.toJson();
 
-        QFile gltfOut(gltfPath);
-        if (gltfOut.exists() && !force) {
-            qCritical("Use --force if you want to overwrite %s\n", gltfPath.toLatin1().constData());
-        }
+    const auto gltfFilename = assetFileInfo.baseName();
+    const auto gltfPath = QStringLiteral("%1/%2.gltf").arg(targetDir.absolutePath(), gltfFilename);
 
-        if (!gltfOut.open(QIODevice::WriteOnly)) {
-            qCritical("Could not open glTF2 file for writing: \n%s", gltfOut.errorString().toLatin1().constData());
-            return 1;
-        }
-
-        gltfOut.write(QJsonDocument{ new_asset.json() }.toJson());
+    QFile gltfOut(gltfPath);
+    if (gltfOut.exists() && !force) {
+        qCritical("Use --force if you want to overwrite %s\n", gltfPath.toLatin1().constData());
     }
 
+    if (!gltfOut.open(QIODevice::WriteOnly)) {
+        qCritical("Could not open glTF2 file for writing: \n%s", gltfOut.errorString().toLatin1().constData());
+        return 1;
+    }
+
+    processedSize += gltfOut.write(newAssetJson);
+
     // Show some stats
-    const auto space_taken = QFileInfo(targetDir.filePath(new_asset.compressedBufferFilename())).size();
-    QTextStream out(stdout);
-    out << QObject::tr("Kuesa: Compressing mesh took %1 milliseconds\n").arg(time_taken / 1000000.);
-    out << QObject::tr("Kuesa: Space taken by compressed meshes: %2 bytes\n").arg(space_taken);
+    if (stats) {
+        SceneEntity scene;
+        GLTF2Context ctx;
+        GLTF2Parser parser(&scene);
+        parser.setContext(&ctx);
+
+        timer.restart();
+        parser.parse(gltfPath);
+        processedParseTime = timer.elapsed();
+
+        for (const auto &file : ctx.localFiles()) {
+            processedSize += QFileInfo(targetDir.filePath(file)).size();
+        }
+
+        QTextStream out(stdout);
+        out << QObject::tr("Kuesa: Space taken by original asset: %1 kilobytes\n").arg(sourceSize / 1000.);
+        out << QObject::tr("Kuesa: Space taken by processed asset: %1 kilobytes\n").arg(processedSize / 1000.);
+        out << QObject::tr("Kuesa: Size delta: %1 kilobytes (%2 % of the original)\n")
+                        .arg((processedSize - sourceSize) / 1000.)
+                        .arg(100. * double(processedSize) / double(sourceSize));
+
+        out << QObject::tr("Kuesa: Initial parsing took %1 milliseconds\n").arg(sourceParseTime);
+        out << QObject::tr("Kuesa: Asset processing took %1 milliseconds\n").arg(exportTime);
+        out << QObject::tr("Kuesa: Parsing the processed asset took %1 milliseconds\n").arg(processedParseTime);
+        out << QObject::tr("Kuesa: Time delta: %1 milliseconds (%2 % of the original)\n")
+                        .arg((processedParseTime - sourceParseTime))
+                        .arg(100. * processedParseTime / sourceParseTime);
+    }
 
     return 0;
 }

--- a/tools/assetprocessor/main.cpp
+++ b/tools/assetprocessor/main.cpp
@@ -3,7 +3,7 @@
 
     This file is part of Kuesa.
 
-    Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
     Author: Jean-Michaël Celerier <jean-michael.celerier@kdab.com>
 
     Licensees holding valid proprietary KDAB Kuesa licenses may use this file in


### PR DESCRIPTION
As mentioned in a previous PR, it is now possible to choose whether one wants to :
- Embed everything in base64 in the gltf file
- Extract every embedded thing
- Keep things as they are

This refactors GLTF2Exporter by separating it in multiple passes (one per file, but this makes a big diff, sorry). 