### PR TITLE
Fix compilation on Android

### DIFF
--- a/src/core/gltf2exporter/dracocompressor_p.cpp
+++ b/src/core/gltf2exporter/dracocompressor_p.cpp
@@ -278,7 +278,7 @@ CompressedMesh compressMesh(
             break;
         }
         case Qt3DRender::QAttribute::VertexBaseType::Byte: {
-            static_assert(CHAR_MIN < 0, "This code only works on platforms with signed char");
+            static_assert (std::numeric_limits<qint8>::min() < 0, "This code only works on platforms with signed char");
             if(!compressAttribute<qint8>(*attribute, dracoMesh, attributes))
                 return {};
             break;


### PR DESCRIPTION
CHAR_MIN doesn't seem to be the same as std::numerit_limits<qint8>::min()
on arm64 Android.