### PR TITLE
Simple gltfViewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Kuesa is composed of:
 * A QML plugin
 * The assetpipelineeditor tool to preview and process glTF 2.0 files
 * The assetprocessor, a command line tool to compress meshes, embed or extract binary assets, etc
+* A simple glTFViewer application to view files, including selecting cameras and animations
 * The cubemaptooctahedralmap tool to convert cube maps to octahedral maps
   to enable PBR rendering on ES 2 platforms
 

--- a/src/quick/imports/kuesaplugin.cpp
+++ b/src/quick/imports/kuesaplugin.cpp
@@ -67,6 +67,7 @@ void KuesaPlugin::registerTypes(const char *uri)
     qmlRegisterUncreatableType<Kuesa::CameraCollection>(uri, 1, 0, "CameraCollection", QStringLiteral("You are not supposed to create a CameraCollection"));
     qmlRegisterUncreatableType<Kuesa::TextureImageCollection>(uri, 1, 0, "TextureImageCollection", QStringLiteral("You are not supposed to create a TextureImageCollection"));
     qmlRegisterUncreatableType<Kuesa::AnimationMappingCollection>(uri, 1, 0, "AnimationMappingCollection", QStringLiteral("You are not supposed to create an AnimationMappingCollection"));
+    qmlRegisterUncreatableType<Kuesa::AnimationClipCollection>(uri, 1, 0, "AnimationClipCollection", QStringLiteral("You are not supposed to create an AnimationClipCollection"));
 
     // FrameGraphs
     qmlRegisterExtendedType<Kuesa::ForwardRenderer, Kuesa::PostFXListExtension>(uri, 1, 0, "ForwardRenderer");

--- a/tools/assetpipelineeditor/orbitcameracontroller.cpp
+++ b/tools/assetpipelineeditor/orbitcameracontroller.cpp
@@ -294,10 +294,12 @@ void OrbitCameraController::setCamera(Qt3DRender::QCamera *camera)
 
         m_camera = camera;
 
-        if (m_camera)
-            connect(m_camera, &Qt3DCore::QNode::nodeDestroyed, this, [this]() {
-                setCamera(nullptr);
+        if (m_camera) {
+            connect(m_camera, &Qt3DCore::QNode::nodeDestroyed, this, [this, camera]() {
+                if (camera == this->m_camera)
+                    setCamera(nullptr);
             });
+        }
 
         emit cameraChanged();
     }

--- a/tools/gltfViewer/Info.plist.in
+++ b/tools/gltfViewer/Info.plist.in
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
+<plist version="0.1">
+<dict>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>CFBundleIconFile</key>
+    <string>kuesa.icns</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.kdab.kuesa.gltfviewer</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleGetInfoString</key>
+    <string></string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleExecutable</key>
+    <string>gltfViewer</string>
+    <key>CFBundleVersion</key>
+    <string>$$VERSION</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$$VERSION</string>
+    <key>CFBundleDisplayName</key>
+    <string>Kuesa Asset Pipeline Editor</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright 2018-2019, KDAB</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>This application needs to send Apple Events</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>gltf</string>
+                <string>glb</string>
+            </array>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/tools/gltfViewer/README.md
+++ b/tools/gltfViewer/README.md
@@ -1,0 +1,39 @@
+# Simple glTL Viewer
+
+The gltfViewer application can be used to view glTF files, including
+selecting cameras and playing animations.
+
+Usage: `gltf [-f] [-c name] [-p name] [-l] file.gltf`
+
+## Options
+
+*  `-h, --help`               : Display help.
+*  `-v, --version`            : Display version information.
+*  `-f, --fullScreen`         : Show full screen.
+*  `-p, --play <animations>`  : Play named animation
+*  `-l, --loop`               : Loop animations
+*  `-c, --camera <camera>`    : Use named camera
+
+
+## Operation
+
+The application will render the glTF file passed as an
+argument on the command line.
+
+On macOS, the application is associated to .gltf and .glb files
+so double clicking on one such file in Finder will launch the
+application.
+
+To load another file, simply drag & drop it onto the main window.
+
+The `--fullscreen` argument can be used to render the scene in full screen.
+Using the `Ctrl-F` key combination will toggle the full screen window.
+
+If one or more cameras are present in the file, the first one
+will initially be used to render the scene. A specific camera can
+be selected using the `--camera <name>` argument. Using the `Tab` 
+and `BackTab` keys will cycle through available cameras.
+
+To play an animation, use the `--play <name>` argument. The animation
+will play once. To play it continuously, use the `--loop` argument.
+The `Space` key can be used to pause or resume the current animation.

--- a/tools/gltfViewer/gltfViewer.pro
+++ b/tools/gltfViewer/gltfViewer.pro
@@ -1,0 +1,42 @@
+QT += 3danimation 3dquickextras kuesa kuesa-private
+CONFIG += resources_big
+VERSION = 1.0.0
+
+DEFINES += QT_DEPRECATED_WARNINGS
+
+SOURCES += main.cpp \
+    ../assetpipelineeditor/orbitcameracontroller.cpp
+
+HEADERS += \
+    ../assetpipelineeditor/orbitcameracontroller.h
+
+RESOURCES += qml.qrc
+    ../../resources/resources.qrc
+
+OTHER_FILES += main.qml
+
+macos {
+    TARGET = gltfViewer
+    OTHER_FILES += Info.plist.in
+    QMAKE_SUBSTITUTES += Info.plist.in
+    QMAKE_INFO_PLIST = $$OUT_PWD/Info.plist
+
+    ICON_FILE.files = ../../resources/kuesa.icns
+    ICON_FILE.path = Contents/Resources
+    QMAKE_BUNDLE_DATA += ICON_FILE
+
+    RESOURCES += \
+        ../../examples/kuesa/assets/envmaps/wobbly_bridge/envmap-wobbly-bridge-16f.qrc
+} else {
+    RESOURCES += \
+        ../../examples/kuesa/assets/envmaps/wobbly_bridge/envmap-wobbly-bridge.qrc
+}
+
+windows {
+    RC_ICONS = ../../resources/kuesa.ico
+}
+
+target.path = $$[QT_INSTALL_BINS]
+INSTALLS += target
+
+OTHER_FILES += README.md

--- a/tools/gltfViewer/main.cpp
+++ b/tools/gltfViewer/main.cpp
@@ -1,0 +1,229 @@
+/*
+    main.cpp
+
+    This file is part of Kuesa.
+
+    Copyright (C) 2018-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+    Author: Mike Krus <mike.krus@kdab.com>
+
+    Licensees holding valid proprietary KDAB Kuesa licenses may use this file in
+    accordance with the Kuesa Enterprise License Agreement provided with the Software in the
+    LICENSE.KUESA.ENTERPRISE file.
+
+    Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <QGuiApplication>
+#include <QCommandLineParser>
+#include <QFileInfo>
+#include <QFileOpenEvent>
+#include <QQmlEngine>
+#include <QQmlContext>
+#include <QMimeData>
+#include <Qt3DQuick/QQmlAspectEngine>
+#include <Qt3DAnimation/QAnimationAspect>
+#include <Qt3DQuickExtras/Qt3DQuickWindow>
+
+#include "../assetpipelineeditor/orbitcameracontroller.h"
+
+class ViewerApplication : public QGuiApplication
+{
+    Q_OBJECT
+public:
+    ViewerApplication(int &argc, char **argv, int aflags);
+    ~ViewerApplication();
+
+    void setContext(QQmlContext *context) { m_context = context; }
+    bool event(QEvent *event) override;
+
+    Q_INVOKABLE void viewAll(Qt3DRender::QCamera *camera);
+    Q_INVOKABLE void reload();
+
+signals:
+    void nextCamera();
+    void previousCamera();
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    QQmlContext *m_context;
+};
+
+ViewerApplication::ViewerApplication(int &argc, char **argv, int aflags = ApplicationFlags)
+    : QGuiApplication(argc, argv, aflags)
+    , m_context(nullptr)
+{
+}
+
+ViewerApplication::~ViewerApplication() = default;
+
+bool ViewerApplication::event(QEvent *event)
+{
+    if (event->type() == QEvent::FileOpen) {
+        QFileOpenEvent *fileEvent = static_cast<QFileOpenEvent *>(event);
+        if (m_context)
+            m_context->setContextProperty("_gltfFile", fileEvent->url());
+    }
+
+    return QGuiApplication::event(event);
+}
+
+bool ViewerApplication::eventFilter(QObject *watched, QEvent *event)
+{
+    switch (event->type()) {
+    case QEvent::Drop: {
+        QDropEvent *de = static_cast<QDropEvent *>(event);
+        if (de->mimeData()->urls().size() == 1) {
+            QUrl u = de->mimeData()->urls().front();
+            if (m_context)
+                m_context->setContextProperty("_gltfFile", u);
+            de->accept();
+            return false;
+        }
+        break;
+    }
+    case QEvent::DragEnter: {
+        QDragEnterEvent *de = static_cast<QDragEnterEvent *>(event);
+        if (de->mimeData()->urls().size() == 1) {
+            QUrl u = de->mimeData()->urls().front();
+            if (u.scheme() != QLatin1String("file"))
+                break;
+            QFileInfo fi(u.toLocalFile());
+            if (!fi.exists() || fi.suffix().toLower() != "gltf")
+                break;
+            de->accept();
+            return false;
+        }
+        break;
+    }
+    case QEvent::Resize: {
+        QResizeEvent *re = static_cast<QResizeEvent *>(event);
+        if (!re->size().isEmpty() && m_context)
+            m_context->setContextProperty("_winSize", re->size());
+        break;
+    }
+    case QEvent::KeyPress: {
+        QKeyEvent *ke = static_cast<QKeyEvent *>(event);
+        if (ke->key() == Qt::Key_F && ke->modifiers() == Qt::ControlModifier) {
+            QWindow *w = qobject_cast<QWindow *>(watched);
+            if (w->windowState() & Qt::WindowFullScreen)
+                w->showNormal();
+            else
+                w->showFullScreen();
+        }
+        break;
+    }
+    default:
+        break;
+    };
+
+    return QGuiApplication::eventFilter(watched, event);
+}
+
+void ViewerApplication::viewAll(Qt3DRender::QCamera *camera)
+{
+    if (!camera)
+        return;
+
+    connect(camera, &Qt3DRender::QCamera::viewMatrixChanged, this, [camera, this]() {
+        const QVector3D position = camera->position();
+        const QVector3D viewCenter = camera->viewCenter();
+        const float sceneExtent = 2.0f * (viewCenter - position).length();
+        camera->setFarPlane(10.0f * sceneExtent); // add some headroom to be able to zoom out
+        camera->setNearPlane(0.001f * sceneExtent);
+        camera->disconnect(this);
+    });
+    camera->viewAll();
+}
+
+void ViewerApplication::reload()
+{
+    if (!m_context)
+        return;
+    QString current = m_context->contextProperty("_gltfFile").toString();
+    m_context->setContextProperty("_gltfFile", "");
+    m_context->setContextProperty("_gltfFile", current);
+}
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication::setApplicationName("gltfViewer");
+    QCoreApplication::setOrganizationDomain("kdab.com");
+    QCoreApplication::setOrganizationName("KDAB");
+    QCoreApplication::setApplicationVersion(QStringLiteral("1.0"));
+
+    qmlRegisterType<OrbitCameraController>("KuesaViewer", 1, 0, "OrbitCameraController");
+
+    ViewerApplication app(argc, argv);
+
+    QCommandLineParser cmdline;
+    cmdline.addHelpOption();
+    cmdline.addVersionOption();
+    cmdline.setApplicationDescription(
+            QObject::tr("\nThis tool renders glTF 2.0 files.\n"
+                        "Example : ./gltfViewer [-f] my_file.gltf"));
+    cmdline.addPositionalArgument("source", QCoreApplication::translate("main", "gltf 2.0 file to render."));
+
+    QCommandLineOption fullScreenOption({ "f", "fullScreen" }, QObject::tr("show full screen."));
+    QCommandLineOption cameraOption({ "c", "camera" }, QObject::tr("use named camera"), QObject::tr("camera"), QString());
+    QCommandLineOption animationsOption({ "p", "play" }, QObject::tr("play named animation"), QObject::tr("animations"), QString());
+    QCommandLineOption loopOption({ "l", "loop" }, QObject::tr("loop animations"));
+    cmdline.addOptions({ fullScreenOption, animationsOption, loopOption, cameraOption });
+
+    cmdline.process(app);
+
+    QUrl inputFile;
+    const QStringList sources = cmdline.positionalArguments();
+    if (!sources.empty()) {
+        QFileInfo fi(sources.front());
+        if (!fi.exists()) {
+            qCritical("Input file not found.\n%s", cmdline.helpText().toLatin1().constData());
+            return 1;
+        }
+        inputFile = QUrl::fromLocalFile(sources.front());
+#ifndef Q_OS_MACOS
+    } else {
+        cmdline.showHelp();
+        return 1;
+#endif
+    }
+
+    Qt3DExtras::Quick::Qt3DQuickWindow view;
+    view.setFlags(view.flags() | Qt::WindowFullscreenButtonHint);
+    view.registerAspect(new Qt3DAnimation::QAnimationAspect());
+    view.installEventFilter(&app);
+
+    QQmlContext *context = view.engine()->qmlEngine()->rootContext();
+    app.setContext(context);
+    context->setContextProperty("_app", &app);
+    context->setContextProperty("_gltfFile", inputFile);
+    context->setContextProperty("_winSize", QSize(1920, 1080));
+    context->setContextProperty("_gltfCamera", cmdline.value(cameraOption));
+    context->setContextProperty("_gltfAnimations", cmdline.values(animationsOption));
+    context->setContextProperty("_gltfLoopAnimations", cmdline.isSet(loopOption));
+    view.setSource(QUrl("qrc:/main.qml"));
+
+    view.resize(1920, 1080);
+    if (cmdline.isSet(fullScreenOption))
+        view.showFullScreen();
+    else
+        view.show();
+
+    return app.exec();
+}
+
+#include "main.moc"

--- a/tools/gltfViewer/main.qml
+++ b/tools/gltfViewer/main.qml
@@ -1,0 +1,149 @@
+import Qt3D.Core 2.12
+import Qt3D.Render 2.12
+import Qt3D.Animation 2.12
+import Qt3D.Input 2.12
+import Qt3D.Extras 2.12
+import Kuesa 1.0 as Kuesa
+import KuesaViewer 1.0 as KuesaViewer
+
+Kuesa.SceneEntity {
+    id: root
+    property int __currentCamera: -1
+
+    property url source: _gltfFile
+    onSourceChanged: {
+        root.clearCollections()
+        animations.running = false
+        importer.source = source
+    }
+
+    Entity {
+        parent: frameGraph.camera
+        components: [
+            PointLight {
+                constantAttenuation: 1.0
+                linearAttenuation: 0.0
+                quadraticAttenuation: 0.0
+            }
+        ]
+    }
+
+    components: [
+        RenderSettings {
+            activeFrameGraph: Kuesa.ForwardRenderer {
+                id: frameGraph
+                camera: cameraAsset.node ? cameraAsset.node : fallbackCamera
+                clearColor: "white"
+            }
+        },
+        InputSettings { },
+        EnvironmentLight {
+            id: envLight
+            property string envMapFormat: Qt.platform.os == "osx" ? "_16f" : ""
+
+            irradiance: TextureLoader {
+                source: "qrc:/wobbly_bridge" + envLight.envMapFormat + "_irradiance.dds"
+                wrapMode {
+                    x: WrapMode.ClampToEdge
+                    y: WrapMode.ClampToEdge
+                }
+                generateMipMaps: false
+            }
+            specular: TextureLoader {
+                source: "qrc:/wobbly_bridge" + envLight.envMapFormat + "_specular.dds"
+                wrapMode {
+                    x: WrapMode.ClampToEdge
+                    y: WrapMode.ClampToEdge
+                }
+                generateMipMaps: false
+            }
+        }
+    ]
+
+    Camera {
+        id: fallbackCamera
+        objectName: "fallbackCamera"
+
+        position: Qt.vector3d(0.0, 0.0, 7.0)
+        upVector: Qt.vector3d(0.0, 1.0, 0.0)
+        viewCenter: Qt.vector3d(0.0, 0.0, 0.0)
+        aspectRatio: _winSize.width / _winSize.height
+    }
+
+    KuesaViewer.OrbitCameraController {
+        id: controller
+        camera: frameGraph.camera
+        windowSize: _winSize
+    }
+
+    Kuesa.Asset {
+        id: cameraAsset
+        name: __currentCamera >= 0 && __currentCamera < root.cameras.names.length ? root.cameras.names[__currentCamera] : ""
+        collection: root.cameras
+        onNodeChanged: {
+            if (node)
+                node.aspectRatio = _winSize.width / _winSize.height
+        }
+    }
+
+    Kuesa.GLTF2Importer {
+        id: importer
+        sceneEntity: root
+        assignNames: true
+    }
+
+    onLoadingDone: {
+        console.log(importer.source)
+        console.log("Cameras:", root.cameras.names)
+        console.log("Animations:", root.animationClips.names)
+        if (root.cameras.names.length === 0) {
+            __currentCamera = -1
+            _app.viewAll(fallbackCamera)
+        } else {
+            __currentCamera = 0
+            for (var i=0; i<root.cameras.names.length; ++i) {
+                if (root.cameras.names[i] === _gltfCamera) {
+                    __currentCamera = i
+                    break
+                }
+            }
+        }
+        animations.model = root.animationClips.names.length ? _gltfAnimations : 0
+        animations.running = root.animationClips.names.length > 0
+    }
+
+    NodeInstantiator {
+        id: animations
+        property bool running: true
+        delegate: Kuesa.AnimationPlayer {
+            sceneEntity: root
+            clip: model.modelData
+            loops: _gltfLoopAnimations ? Kuesa.AnimationPlayer.Infinite : 1
+            running: animations.running
+        }
+    }
+
+    KeyboardDevice { id: kb }
+    KeyboardHandler {
+        sourceDevice: kb
+        focus: true
+
+        onTabPressed: {
+            if (__currentCamera != -1) {
+                if (++__currentCamera >= root.cameras.names.length)
+                    __currentCamera = 0
+            }
+        }
+        onBacktabPressed: {
+            if (__currentCamera != -1) {
+                if (--__currentCamera < 0)
+                    __currentCamera = root.cameras.names.length - 1
+            }
+        }
+        onSpacePressed: animations.running = !animations.running
+        onPressed: {
+            if (event.key === Qt.Key_R && event.modifiers === Qt.ControlModifier)
+                _app.reload()
+        }
+    }
+}

--- a/tools/gltfViewer/qml.qrc
+++ b/tools/gltfViewer/qml.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>main.qml</file>
+    </qresource>
+</RCC>

--- a/tools/tools.pro
+++ b/tools/tools.pro
@@ -30,7 +30,8 @@ TEMPLATE = subdirs
     SUBDIRS += \
         assetpipelineeditor \
         ddspreviewer \
-        assetprocessor
+        assetprocessor \
+        gltfViewer
 
     !macos {
         SUBDIRS += \


### PR DESCRIPTION
Opens and renders gltf files using just a QWindow, no QML, no widgets.
On macOS this gets associated to .gltf files.
Supports drag & dropping files on the opened window.

Will be useful to debug performance without interference from other rendering.