### PR TITLE
Put resources in external files in the common case.

### DIFF
--- a/examples/kuesa/car-scene/car-scene.pro
+++ b/examples/kuesa/car-scene/car-scene.pro
@@ -105,24 +105,24 @@ android {
     OTHER_FILES += Info-macos.plist
     QMAKE_INFO_PLIST = Info-macos.plist
 } else {
-    RESOURCES += \
+    RCC_BINARY_SOURCES += \
         ../assets/models/car/car_images.qrc
 
     qtConfig(draco) {
-        RESOURCES += \
+        RCC_BINARY_SOURCES += \
             ../assets/models/car/car-draco.qrc
     } else {
-        RESOURCES += \
+        RCC_BINARY_SOURCES += \
             ../assets/models/car/car.qrc
     }
 
-    RESOURCES += \
+    RCC_BINARY_SOURCES += \
         ../assets/envmaps/pink_sunrise/envmap-pink-sunrise.qrc \
         ../assets/envmaps/neuer_zollhof/envmap-neuer-zollhof.qrc \
         ../assets/envmaps/kdab-studiosky-small/envmap-kdab-studiosky-small.qrc
 
     qtConfig(opengles2) {
-        RESOURCES += \
+        RCC_BINARY_SOURCES += \
             ../assets/envmaps/kdab-studiosky-small/envmap-kdab-studiosky-small-16f.qrc \
             ../assets/envmaps/pink_sunrise/envmap-pink-sunrise-16f.qrc \
             ../assets/envmaps/neuer_zollhof/envmap-neuer-zollhof-16f.qrc
@@ -131,7 +131,21 @@ android {
     windows {
         RC_ICONS = ../../../resources/kuesa.ico
     }
+
+    # Build resources as external files
+    asset_builder.commands = $$[QT_HOST_BINS]/rcc -binary ${QMAKE_FILE_IN} -o ${QMAKE_FILE_OUT} -no-compress
+    asset_builder.depend_command = $$[QT_HOST_BINS]/rcc -list $$QMAKE_RESOURCE_FLAGS ${QMAKE_FILE_IN}
+    asset_builder.input = RCC_BINARY_SOURCES
+    asset_builder.output = $$OUT_PWD/resources/${QMAKE_FILE_IN_BASE}.qrb
+    asset_builder.CONFIG += no_link target_predeps
+    QMAKE_EXTRA_COMPILERS += asset_builder
+
+    ext_resources.path = $$[QT_INSTALL_EXAMPLES]/kuesa/$$TARGET/resources
+    ext_resources.files = $$OUT_PWD/resources/*
+
+    INSTALLS += ext_resources
 }
 
 target.path = $$[QT_INSTALL_EXAMPLES]/kuesa/$$TARGET
 INSTALLS += target
+

--- a/examples/kuesa/car-scene/main.cpp
+++ b/examples/kuesa/car-scene/main.cpp
@@ -34,6 +34,9 @@
 #include <QCommandLineParser>
 #include <QCommandLineOption>
 #include <QStandardPaths>
+#include <QDir>
+#include <QDirIterator>
+#include <QResource>
 
 int main(int ac, char **av)
 {
@@ -56,6 +59,12 @@ int main(int ac, char **av)
     }
 
     QGuiApplication app(ac, av);
+
+    QDir resourceDir(app.applicationDirPath() + QStringLiteral("/resources"));
+    QDirIterator it(resourceDir, QDirIterator::IteratorFlag::NoIteratorFlags);
+    while (it.hasNext()) {
+        QResource::registerResource(it.next());
+    }
 
     QCommandLineParser parser;
     parser.setApplicationDescription("KDAB Kuesa Demo");


### PR DESCRIPTION
This looks like it is necessary for arm boards where the linker fails
due to the large dds files.