### PR TITLE
Threaded parsing

### DIFF
--- a/src/core/gltf2importer/gltf2importer.cpp
+++ b/src/core/gltf2importer/gltf2importer.cpp
@@ -323,23 +323,36 @@ void GLTF2Importer::setAssignNames(bool assignNames)
 
 void GLTF2Importer::load()
 {
+    if (status() == Status::Loading)
+        return;
+
     setStatus(GLTF2Importer::Status::Loading);
     *m_context = {};
 
     const QString path = urlToLocalFileOrQrc(m_source);
 
-    GLTF2Import::GLTF2Parser parser(m_sceneEntity, m_assignNames);
-    parser.setContext(m_context);
+    auto parser = new GLTF2Import::ThreadedGLTF2Parser(m_context, m_sceneEntity, m_assignNames);
+
+    connect(
+            parser, &GLTF2Import::ThreadedGLTF2Parser::parsingFinished,
+            this, [this, parser](Qt3DCore::QEntity *root) {
+                m_root = root;
+
+                if (m_root) {
+                    m_root->setParent(this);
+                    if (m_sceneEntity)
+                        emit m_sceneEntity->loadingDone();
+                    setStatus(GLTF2Importer::Status::Ready);
+                } else {
+                    setStatus(GLTF2Importer::Status::Error);
+                }
+
+                parser->deleteLater();
+            },
+            Qt::QueuedConnection);
 
     Q_ASSERT(m_root == nullptr);
-    m_root = parser.parse(path);
-    if (m_root) {
-        m_root->setParent(this);
-        if (m_sceneEntity)
-            emit m_sceneEntity->loadingDone();
-    }
-
-    setStatus(m_root ? GLTF2Importer::Status::Ready : GLTF2Importer::Status::Error);
+    parser->parse(path);
 }
 
 void GLTF2Importer::clear()

--- a/tests/auto/gltfexporter/tst_gltfexporter.cpp
+++ b/tests/auto/gltfexporter/tst_gltfexporter.cpp
@@ -307,7 +307,8 @@ private Q_SLOTS:
             QVERIFY(exported.success());
 
             ctx = GLTF2Context{};
-            auto res = parser.parseJSON(QJsonDocument{ exported.json() }.toJson(), tmp.absolutePath(), QStringLiteral("test.gltf"));
+            parser.parseJSON(QJsonDocument{ exported.json() }.toJson(), tmp.absolutePath(), QStringLiteral("test.gltf"));
+            auto res = parser.setupScene();
             QVERIFY(res != nullptr);
 
             QVERIFY(tmp.exists(exported.compressedBufferFilename()));
@@ -374,7 +375,7 @@ private Q_SLOTS:
 
             // Some non-mesh data remains
             QFileInfo dodge_info(tmp.filePath("DodgeViper.bin"));
-            QVERIFY(dodge_info.size() == 21898);
+            QCOMPARE(dodge_info.size(), 21898);
 
             // Compressed mesh is less than a megabyte
             QFileInfo comp_info(tmp.filePath(exported.compressedBufferFilename()));
@@ -383,7 +384,9 @@ private Q_SLOTS:
 
             // Check that we can reload the mesh properly
             ctx = GLTF2Context{};
-            auto res = parser.parseJSON(QJsonDocument{ exported.json() }.toJson(), tmp.absolutePath(), QStringLiteral("test.gltf"));
+            parser.parseJSON(QJsonDocument{ exported.json() }.toJson(), tmp.absolutePath(), QStringLiteral("test.gltf"));
+
+            auto res = parser.setupScene();
             QVERIFY(res != nullptr);
         }
     }
@@ -438,7 +441,8 @@ private Q_SLOTS:
 
             // Check that we can reload the mesh properly
             ctx = GLTF2Context{};
-            auto res = parser.parseJSON(QJsonDocument{ exported.json() }.toJson(), tmp.absolutePath(), QStringLiteral("test.gltf"));
+            parser.parseJSON(QJsonDocument{ exported.json() }.toJson(), tmp.absolutePath(), QStringLiteral("test.gltf"));
+            auto res = parser.setupScene();
             QVERIFY(res != nullptr);
         }
     }
@@ -548,7 +552,8 @@ private Q_SLOTS:
             QCOMPARE(sub.count(), 1U);
 
             ctx = GLTF2Context{};
-            auto res = parser.parseJSON(QJsonDocument{ exported.json() }.toJson(), sub.absolutePath(), QStringLiteral("test.gltf"));
+            parser.parseJSON(QJsonDocument{ exported.json() }.toJson(), sub.absolutePath(), QStringLiteral("test.gltf"));
+            auto res = parser.setupScene();
             QVERIFY(res != nullptr);
         }
     }


### PR DESCRIPTION
This puts the main glTF parsing in a QThread.
Some wrangling is needed because adding elements to the SceneEntity has to be done in the GUI thread, so the main `parse` method is split between `parse` which only does parsing and works in another thread, and `setupScene` which needs to be called from the gui thread.
There are certainly still some thread-safety bugs - it would be safer I think to restart from a new
clean SceneEntity when loading.

Maybe the approach is woefully incorrect - please bash :)