### PR TITLE
Fix selection material

### DIFF
--- a/src/core/metallicroughnesseffect.h
+++ b/src/core/metallicroughnesseffect.h
@@ -59,6 +59,7 @@ class KUESASHARED_EXPORT MetallicRoughnessEffect : public Qt3DRender::QEffect
     Q_PROPERTY(bool opaque READ isOpaque WRITE setOpaque NOTIFY opaqueChanged)
     Q_PROPERTY(bool alphaCutoffEnabled READ isAlphaCutoffEnabled WRITE setAlphaCutoffEnabled NOTIFY alphaCutoffEnabledChanged)
     Q_PROPERTY(MetallicRoughnessEffect::ToneMapping toneMappingAlgorithm READ toneMappingAlgorithm WRITE setToneMappingAlgorithm NOTIFY toneMappingAlgorithmChanged REVISION 1)
+    Q_PROPERTY(Qt3DRender::QAbstractTexture *brdfLUT READ brdfLUT WRITE setBrdfLUT NOTIFY brdfLUTChanged REVISION 1)
 
 public:
     enum ToneMapping {
@@ -81,7 +82,7 @@ public:
     bool isOpaque() const;
     bool isAlphaCutoffEnabled() const;
     ToneMapping toneMappingAlgorithm() const;
-    void setBrdfLUT(Qt3DRender::QAbstractTexture *brdfLUT);
+    Qt3DRender::QAbstractTexture *brdfLUT() const;
 
 public Q_SLOTS:
     void setBaseColorMapEnabled(bool enabled);
@@ -95,6 +96,7 @@ public Q_SLOTS:
     void setOpaque(bool opaque);
     void setAlphaCutoffEnabled(bool enabled);
     void setToneMappingAlgorithm(ToneMapping algorithm);
+    void setBrdfLUT(Qt3DRender::QAbstractTexture *brdfLUT);
 
 Q_SIGNALS:
     void baseColorMapEnabledChanged(bool enabled);
@@ -108,6 +110,7 @@ Q_SIGNALS:
     void opaqueChanged(bool opaque);
     void alphaCutoffEnabledChanged(bool enabled);
     void toneMappingAlgorithmChanged(ToneMapping algorithm);
+    void brdfLUTChanged(Qt3DRender::QAbstractTexture *brdfLUT);
 
 private:
     bool m_baseColorMapEnabled;

--- a/tools/assetpipelineeditor/meshinspector.cpp
+++ b/tools/assetpipelineeditor/meshinspector.cpp
@@ -79,9 +79,19 @@ void MeshInspector::setMesh(Qt3DRender::QGeometryRenderer *mesh)
             m_highlightMaterial->setAlphaCutoffEnabled(false);
         }
 
+        bool setBrdfLUT = true;
         for (Qt3DCore::QEntity *entity : entities) {
             Kuesa::MetallicRoughnessMaterial *mat = Kuesa::componentFromEntity<Kuesa::MetallicRoughnessMaterial>(entity);
             if (mat != nullptr) {
+                if (setBrdfLUT) {
+                    // copy the brdfLUT texture from the current material to the highlight material
+                    const auto *srcEffect = qobject_cast<Kuesa::MetallicRoughnessEffect *>(mat->effect());
+                    auto *highlightEffect = qobject_cast<Kuesa::MetallicRoughnessEffect *>(m_highlightMaterial->effect());
+                    if (srcEffect && highlightEffect)
+                        highlightEffect->setBrdfLUT(srcEffect->brdfLUT());
+                    setBrdfLUT = false;
+                }
+
                 // Replace entity material with highlight material
                 entity->removeComponent(mat);
                 entity->addComponent(m_highlightMaterial.data());


### PR DESCRIPTION
Special highlight material still needs.brdfLUT texture. We steel it
from the material of the selected entity. Needs to be done every time
in case another model was loaded and the previous texture was deleted.

Q: what happens when the texture is deleted, does the QParameter know about it?
Does the effect need to track the life time of the texture then? Or should it be 
promoted as a proper parameter like the other maps?