### PR TITLE
add required extensions for ES2 HDR IBL

### DIFF
--- a/src/core/shaders/es2/light.inc.frag
+++ b/src/core/shaders/es2/light.inc.frag
@@ -26,6 +26,9 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#extension OES_texture_float : require
+#extension OES_texture_float_linear : require
+
 #ifndef FP
 #define FP highp
 #endif


### PR DESCRIPTION
OES_texture_float and OES_texture_float_linear have been enabled for ES2. Maybe we would prefer to `require` them instead?

Task-Id: KUE-643