### PR TITLE
car-scene: fix OpenGL version resolution on Android

### DIFF
--- a/examples/kuesa/car-scene/main.cpp
+++ b/examples/kuesa/car-scene/main.cpp
@@ -38,6 +38,10 @@
 #include <QDirIterator>
 #include <QResource>
 
+#ifdef  Q_OS_ANDROID
+#include <QOpenGLContext>
+#endif
+
 int main(int ac, char **av)
 {
     bool isES2 = false;
@@ -99,6 +103,16 @@ int main(int ac, char **av)
 
 #ifdef Q_OS_ANDROID
     const QString assetsPrefix = QStringLiteral("assets:/");
+
+    // Qt builds for android may not define QT_OPENGL_ES_3
+    // Therefore we need a runtime check to see whether we can use ES 3.0 or not
+    QOpenGLContext ctx;
+    ctx.setFormat(QSurfaceFormat::defaultFormat());
+    if (ctx.create()) {
+        const QSurfaceFormat androidFormat = ctx.format();
+        isES2 = (androidFormat.majorVersion() == 2);
+    }
+
 #elif defined(Q_OS_IOS)
     const QString assetsPrefix = QString(QStringLiteral("file://%1/Library/Application Support/")).arg(QGuiApplication::applicationDirPath());
 #elif defined(Q_OS_OSX)


### PR DESCRIPTION
Qt really resolves OpenGL features available at run time on Android.
Despite only supporting ES2 at compile time, we may well have ES3 available at
runtime. Adjust the code to check against a runtime context to properly deduce
whether ES2 is available.
If not done, we might end up in a case where Qt3D resolves ES3 but the application
expects the use of ES2 octahedral assets which would leave us in a state where
assets are incompatible with the OpenGL technique used at runtime.