### PR TITLE
Revert "add required extensions for ES2 HDR IBL"

### DIFF
--- a/src/core/shaders/es2/light.inc.frag
+++ b/src/core/shaders/es2/light.inc.frag
@@ -26,9 +26,6 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#extension OES_texture_float : require
-#extension OES_texture_float_linear : require
-
 #ifndef FP
 #define FP highp
 #endif


### PR DESCRIPTION
This reverts commit 62195e84437983462eeb2e4cf4ac6cbccad8f84a which breaks on the platform it's supposed to fix.

The extension settings must come BEFORE any glsl code, not sure how you achieve that with the shader builder.