### PR TITLE
Disable auto detection of Draco on Android and WinRT

### DIFF
--- a/src/core/configure.json
+++ b/src/core/configure.json
@@ -21,6 +21,7 @@
     "features": {
         "draco": {
             "label": "Draco",
+            "autoDetect": "!config.uikit && !config.android && !config.winrt",
             "output": [
                 "publicFeature",
                 "feature",
@@ -32,6 +33,7 @@
             "enable": "input.draco == 'system'",
             "disable": "input.draco != 'system'",
             "condition": "features.draco && libs.draco",
+            "autoDetect": "!config.android && !config.winrt",
             "output": [
                 "publicFeature",
                 { "type": "define", "name": "KUESA_DRACO_COMPRESSION" }


### PR DESCRIPTION
Qt doesn't offer a way to distinguish between desktop Darwin platforms
and mobile ones (iOS). We therefore leave it enabled for Darwin.