### PR TITLE
Use brdfLut texture in texture collection for pbr effect

### DIFF
--- a/src/core/gltf2importer/gltf2parser.cpp
+++ b/src/core/gltf2importer/gltf2parser.cpp
@@ -916,10 +916,8 @@ void GLTF2Parser::generateTreeNodeContent()
 
                         auto setBrdfLutOnEffect = [this](GLTF2Material *m) {
                             auto effect = qobject_cast<MetallicRoughnessEffect *>(m->effect());
-                            if (effect && m_sceneEntity) {
-                                auto texture = m_sceneEntity->texture(QLatin1String("_kuesa_brdfLUT"));
-                                effect->setBrdfLUT(texture);
-                            }
+                            if (effect && m_sceneEntity)
+                                effect->setBrdfLUT(m_sceneEntity->brdfLut());
                         };
 
                         auto checkMaterialIsCompatibleWithPrimitive = [](GLTF2Material *m, Qt3DRender::QGeometryRenderer *renderer,

--- a/src/core/metallicroughnessmaterial.h
+++ b/src/core/metallicroughnessmaterial.h
@@ -128,6 +128,9 @@ public Q_SLOTS:
 
     void setToneMappingAlgorithm(MetallicRoughnessEffect::ToneMapping algorithm);
 
+private Q_SLOTS:
+    void onAddedToEntity(Qt3DCore::QEntity *entity);
+
 Q_SIGNALS:
     void baseColorUsesTexCoord1Changed(bool);
     void metallicRoughnessUsesTexCoord1Changed(bool);

--- a/src/core/sceneentity.cpp
+++ b/src/core/sceneentity.cpp
@@ -117,7 +117,6 @@ SceneEntity::SceneEntity(Qt3DCore::QNode *parent)
     m_brdfLUT->setObjectName("_kuesa_brdfLUT");
     m_brdfLUT->setSource(QUrl(QLatin1String("qrc:/kuesa/shaders/brdfLUT.png")));
     m_brdfLUT->setWrapMode(Qt3DRender::QTextureWrapMode(Qt3DRender::QTextureWrapMode::ClampToEdge));
-    m_textures->add(QLatin1String("_kuesa_brdfLUT"), m_brdfLUT);
 }
 
 SceneEntity::~SceneEntity() = default;
@@ -338,9 +337,6 @@ void SceneEntity::clearCollections()
     m_entities->clear();
     m_textureImages->clear();
     m_animationMappings->clear();
-
-    // TODO: Re-add required assets
-    m_textures->add(QLatin1String("_kuesa_brdfLUT"), m_brdfLUT);
 }
 
 /*!
@@ -359,6 +355,35 @@ Qt3DCore::QNode *SceneEntity::transformForEntity(const QString &name)
         return nullptr;
 
     return componentFromEntity<Qt3DCore::QTransform>(e);
+}
+
+/*!
+ * \brief SceneEntity::brdfLut Returns the brdfLut texture stored in the SceneEntity
+ *
+ * The brdfLut is used as a lookup texture and is needed for the metallic roughness effect
+ * instances. The metallic roughness effect will use the brdfLut texture
+ * stored in the SceneEntity if the user doesn't provide another one.
+ * This allows to share the same texture instance between all the instances of
+ * the metallic roughness effect.
+ *
+ * https://learnopengl.com/PBR/IBL/Specular-IBL
+ */
+Qt3DRender::QAbstractTexture *SceneEntity::brdfLut() const
+{
+    return m_brdfLUT;
+}
+
+Kuesa::SceneEntity *Kuesa::SceneEntity::findParentSceneEntity(Qt3DCore::QEntity *entity)
+{
+    auto *parentEntity = entity->parentEntity();
+    if (parentEntity) {
+        auto *sceneEntity = qobject_cast<Kuesa::SceneEntity *>(parentEntity);
+        if (sceneEntity)
+            return sceneEntity;
+
+        return findParentSceneEntity(parentEntity);
+    }
+    return nullptr;
 }
 
 QT_END_NAMESPACE

--- a/src/core/sceneentity.h
+++ b/src/core/sceneentity.h
@@ -70,6 +70,7 @@ class KUESASHARED_EXPORT SceneEntity : public Qt3DCore::QEntity
     Q_PROPERTY(Kuesa::EntityCollection *entities READ entities NOTIFY loadingDone)
     Q_PROPERTY(Kuesa::TextureImageCollection *textureImages READ textureImages NOTIFY loadingDone)
     Q_PROPERTY(Kuesa::AnimationMappingCollection *animationMappings READ animationMappings NOTIFY loadingDone)
+    Q_PROPERTY(Qt3DRender::QAbstractTexture *brdfLut READ brdfLut CONSTANT)
 
 public:
     SceneEntity(Qt3DCore::QNode *parent = nullptr);
@@ -114,6 +115,10 @@ public:
     Q_INVOKABLE void clearCollections();
 
     Q_INVOKABLE Qt3DCore::QNode *transformForEntity(const QString &name);
+
+    Q_INVOKABLE Qt3DRender::QAbstractTexture *brdfLut() const;
+
+    static SceneEntity *findParentSceneEntity(Qt3DCore::QEntity *entity);
 
 Q_SIGNALS:
     void loadingDone();

--- a/tests/manual/metallicroughnessmaterial/main.qml
+++ b/tests/manual/metallicroughnessmaterial/main.qml
@@ -33,7 +33,7 @@ import Qt3D.Animation 2.10
 import Qt3D.Extras 2.10
 import Kuesa 1.1 as Kuesa
 
-Entity {
+Kuesa.SceneEntity {
     id: scene
 
     components: [


### PR DESCRIPTION
When the material component is added to an entity, it searches for a SceneEntiy and if found, uses the brdfLut texture in the texture collection. 